### PR TITLE
User API Swagger 구체화

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/user/controller/UserController.java
+++ b/src/main/java/mallang_trip/backend/domain/user/controller/UserController.java
@@ -1,16 +1,11 @@
 package mallang_trip.backend.domain.user.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import java.io.UnsupportedEncodingException;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +23,7 @@ import mallang_trip.backend.domain.user.dto.UserBriefResponse;
 import mallang_trip.backend.domain.user.service.UserSearchService;
 import mallang_trip.backend.domain.user.service.UserService;
 import mallang_trip.backend.domain.user.service.UserWithdrawalService;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,6 +44,14 @@ public class UserController {
 
 	@PostMapping("/signup")
 	@ApiOperation(value = "회원가입")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 403, message = "유효하지 않은 imp_uid 입니다."),
+		@ApiResponse(code = 409, message = "중복된 값이 존재합니다."),
+		@ApiResponse(code = 500, message = "본인인증 서버 통신 실패.")
+	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<String> signup(@RequestBody @Valid SignupRequest request)
 		throws BaseException {
 		userService.signup(request);
@@ -55,20 +59,43 @@ public class UserController {
 	}
 
 	@PostMapping("/login")
-	@ApiOperation(value = "로그인", notes = "로그인 성공 시 access token, refresh token 발급")
+	@ApiOperation(value = "로그인", notes = "로그인 성공 시 Access Token, Refresh Token 을 발급합니다.")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "사용자 인증에 실패했습니다.")
+	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<TokensDto> login(@RequestBody @Valid LoginRequest request)
 		throws BaseException {
 		return new BaseResponse<>(userService.login(request));
 	}
 
 	@GetMapping("/auth")
-	@ApiOperation(value = "Auth", notes = "access token 으로 로그인 정보 조회")
+	@ApiOperation(value = "Auth", notes = "Access Token 으로 로그인 정보를 조회합니다.")
+	@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class)
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "사용자 인증에 실패했습니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Access Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Access Token 입니다.")
+	})
+	@PreAuthorize("isAuthenticated()") // 로그인 사용자
 	public BaseResponse<AuthResponse> auth() throws BaseException {
 		return new BaseResponse<>(userService.auth());
 	}
 
 	@GetMapping("/refresh-token")
-	@ApiOperation(value = "Refresh Token", notes = "access token 만료 시, refresh token 으로 재발급 받기")
+	@ApiOperation(value = "Refresh Token", notes = "Refresh Token 으로 Access Token 을 재발급 받습니다.")
+	@ApiImplicitParam(name = "refresh-token", value = "Refresh Token", required = true, paramType = "header", dataTypeClass = String.class)
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<TokensDto> refreshToken() throws BaseException {
 		return new BaseResponse<>(userService.refreshToken());
 	}
@@ -76,13 +103,15 @@ public class UserController {
 	@GetMapping("/check-duplication")
 	@ApiOperation(value = "중복 확인", notes = "회원가입 시 중복 확인")
 	@ApiImplicitParams({
-		@ApiImplicitParam(name = "type", value = "[phoneNumber/loginId/email/nickname] 중 하나"),
-		@ApiImplicitParam(name = "value", value = "중복 확인할 값")
+		@ApiImplicitParam(name = "type", value = "[phoneNumber/loginId/email/nickname] 중 하나", required = true, paramType = "query", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "value", value = "중복 확인할 값", required = true, paramType = "query", dataTypeClass = String.class)
 	})
 	@ApiResponses({
-		@ApiResponse(code = 200, message = "사용가능"),
-		@ApiResponse(code = 409, message = "중복(사용불가)")
+		@ApiResponse(code = 200, message = "사용 가능한 값입니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 409, message = "사용 불가한(중복된) 값입니다.")
 	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<String> checkDuplication(@RequestParam String type,
 		@RequestParam String value) throws BaseException {
 		userService.checkDuplication(type, value);
@@ -90,60 +119,133 @@ public class UserController {
 	}
 
 	@GetMapping("/certification")
-	@ApiOperation(value = "(아이디 찾기/비밀번호 찾기) SMS 인증번호 요청")
+	@ApiOperation(value = "SMS 인증번호 요청", notes = "아이디/비밀번호 찾기를 위한 SMS 인증번호를 발송합니다. 인증번호의 유효시간은 5분입니다.")
+	@ApiImplicitParam(name = "phoneNumber", value = "휴대폰 번호", required = true, paramType = "query", dataTypeClass = String.class)
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 404, message = "해당 휴대폰 번호로 가입된 정보가 없습니다."),
+		@ApiResponse(code = 500, message = "SMS 발송 서버 통신 실패.")
+	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<String> sendSmsCertification(@RequestParam String phoneNumber)
-		throws BaseException, UnsupportedEncodingException, URISyntaxException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+		throws BaseException {
 		userService.sendSmsCertification(phoneNumber);
 		return new BaseResponse<>("성공");
 	}
 
 	@GetMapping("/certification/id")
-	@ApiOperation(value = "(아이디 찾기)SMS 인증번호 확인")
+	@ApiOperation(value = "(아이디 찾기)SMS 인증번호 확인", notes = "인증번호 일치 시, 가입된 로그인 아이디를 반환합니다.")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "phoneNumber", value = "휴대폰 번호", required = true, paramType = "query", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "code", value = "인증번호", required = true, paramType = "query", dataTypeClass = String.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증번호가 일치하지 않습니다."),
+		@ApiResponse(code = 404, message = "해당 휴대폰 번호로 가입된 정보가 없습니다."),
+	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<LoginIdResponse> findId(@RequestParam String phoneNumber,
 		@RequestParam String code) throws BaseException {
 		return new BaseResponse<>(userService.findId(phoneNumber, code));
 	}
 
 	@GetMapping("/certification/password")
-	@ApiOperation(value = "(비밀번호 찾기)SMS 인증번호 확인")
+	@ApiOperation(value = "(비밀번호 찾기)SMS 인증번호 확인", notes = "인증번호 일치 시, 인증번호 유효시간을 5분 연장(재설정)합니다.")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "phoneNumber", value = "휴대폰 번호", required = true, paramType = "query", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "code", value = "인증번호", required = true, paramType = "query", dataTypeClass = String.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증번호가 일치하지 않습니다.")
+	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<String> findPassword(@RequestParam String phoneNumber,
 		@RequestParam String code) throws BaseException {
-		return new BaseResponse<>(userService.findPassword(phoneNumber, code));
+		userService.findPassword(phoneNumber, code);
+		return new BaseResponse<>("성공");
 	}
 
 	@PutMapping("/certification/password")
-	@ApiOperation(value = "(비밀번호 찾기)비밀번호 초기화")
-	public BaseResponse<String> resetPassword(@RequestBody ResetPasswordRequest request)
+	@ApiOperation(value = "(비밀번호 찾기)비밀번호 초기화", notes = "인증번호 일치 시, 새로운 비밀번호로 변경합니다.")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증번호가 일치하지 않습니다."),
+		@ApiResponse(code = 404, message = "해당 휴대폰 번호로 가입된 정보가 없습니다.")
+	})
+	@PreAuthorize("permitAll()") // anyone
+	public BaseResponse<String> resetPassword(@RequestBody @Valid ResetPasswordRequest request)
 		throws BaseException {
 		userService.resetPassword(request);
 		return new BaseResponse<>("성공");
 	}
 
 	@PutMapping("/password")
-	@ApiOperation(value = "비밀번호 변경")
-	public BaseResponse<String> changePassword(@RequestBody ChangePasswordRequest request)
+	@ApiOperation(value = "비밀번호 변경", notes = "기존 비밀번호 일치 시, 새 비밀번호로 재설정합니다.")
+	@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class)
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자이거나, 비밀번호가 일치하지 않습니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Access Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Access Token 입니다.")
+	})
+	@PreAuthorize("isAuthenticated()") // 로그인 사용자
+	public BaseResponse<String> changePassword(@RequestBody @Valid ChangePasswordRequest request)
 		throws BaseException {
 		userService.changePassword(request);
 		return new BaseResponse<>("성공");
 	}
 
 	@PutMapping("/profile")
-	@ApiOperation(value = "프로필 변경")
-	public BaseResponse<String> changeProfile(@RequestBody ChangeProfileRequest request)
+	@ApiOperation(value = "프로필 변경", notes = "입력한 값으로 프로필을 변경합니다. 변경하지 않는 값이라도 기존 값을 입력해야 합니다.")
+	@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class)
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 409, message = "중복된 값이 존재합니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Access Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Access Token 입니다.")
+	})
+	@PreAuthorize("isAuthenticated()") // 로그인 사용자
+	public BaseResponse<String> changeProfile(@RequestBody @Valid ChangeProfileRequest request)
 		throws BaseException {
 		userService.changeProfile(request);
 		return new BaseResponse<>("성공");
 	}
 
 	@GetMapping("/user/search")
-	@ApiOperation(value = "유저 검색 by 닉네임")
+	@ApiOperation(value = "유저 검색", notes = "닉네임으로 다른 유저를 검색합니다.")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "nickname", value = "닉네임", required = true, paramType = "query", dataTypeClass = String.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Access Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Access Token 입니다.")
+	})
+	@PreAuthorize("isAuthenticated()") // 로그인 사용자
 	public BaseResponse<List<UserBriefResponse>> searchUserByNickname(@RequestParam String nickname)
 		throws BaseException {
 		return new BaseResponse<>(userSearchService.findByNickname(nickname));
 	}
 
 	@GetMapping("/user/info/{userId}")
-	@ApiOperation(value = "유저 정보 보기")
+	@ApiOperation(value = "유저 정보 보기", notes = "user_id 로 다른 유저의 정보를 조회합니다.")
+	@ApiImplicitParam(name = "userId", value = "user_id", required = true, paramType = "path", dataTypeClass = Long.class)
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 404, message = "해당 유저를 찾을 수 없습니다.")
+	})
+	@PreAuthorize("permitAll()") // anyone
 	public BaseResponse<UserBriefResponse> getUserInfo(@PathVariable(value = "userId") Long userId)
 		throws BaseException {
 		return new BaseResponse<>(userSearchService.getUserBriefInfo(userId));
@@ -151,6 +253,15 @@ public class UserController {
 
 	@DeleteMapping("/user/withdrawal")
 	@ApiOperation(value = "회원탈퇴")
+	@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class)
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "요청에 성공했습니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 403, message = "회원탈퇴가 불가능합니다. 진행중인 여행이 존재하거나, 미납금이 존재합니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Access Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Access Token 입니다.")
+	})
+	@PreAuthorize("isAuthenticated()") // 로그인 사용자
 	public BaseResponse<String> withdrawal() throws BaseException {
 		userWithdrawalService.withdrawal();
 		return new BaseResponse<>("성공");

--- a/src/main/java/mallang_trip/backend/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/user/dto/ChangePasswordRequest.java
@@ -1,5 +1,7 @@
 package mallang_trip.backend.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,6 +9,11 @@ import lombok.Getter;
 @Getter
 public class ChangePasswordRequest {
 
+    @NotBlank
+    @ApiModelProperty(value = "기존 비밀번호", required = true)
     private String before;
+
+    @NotBlank
+    @ApiModelProperty(value = "새 비밀번호", required = true)
     private String after;
 }

--- a/src/main/java/mallang_trip/backend/domain/user/dto/ChangeProfileRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/user/dto/ChangeProfileRequest.java
@@ -1,5 +1,7 @@
 package mallang_trip.backend.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,8 +9,17 @@ import lombok.Getter;
 @Getter
 public class ChangeProfileRequest {
 
+    @NotBlank
+    @ApiModelProperty(value = "이메일", required = true)
     private String email;
+
+    @NotBlank
+    @ApiModelProperty(value = "닉네임", required = true)
     private String nickname;
+
+    @ApiModelProperty(value = "자기소개", required = false)
     private String introduction;
+
+    @ApiModelProperty(value = "프로필 이미지 URL", required = false)
     private String profileImg;
 }

--- a/src/main/java/mallang_trip/backend/domain/user/dto/LoginRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/user/dto/LoginRequest.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,9 +11,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 public class LoginRequest {
 
     @NotBlank
+    @ApiModelProperty(value = "로그인 아이디", required = true)
     private String id;
 
     @NotBlank
+    @ApiModelProperty(value = "비밀번호", required = true)
     private String password;
 
     // 아이디-비밀번호 일치 검증 로직

--- a/src/main/java/mallang_trip/backend/domain/user/dto/ResetPasswordRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/user/dto/ResetPasswordRequest.java
@@ -1,5 +1,7 @@
 package mallang_trip.backend.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,7 +9,15 @@ import lombok.Getter;
 @Builder
 public class ResetPasswordRequest {
 
+    @NotBlank
+    @ApiModelProperty(value = "인증번호", required = true)
     private String code;
+
+    @NotBlank
+    @ApiModelProperty(value = "휴대폰 번호", required = true)
     private String phoneNumber;
+
+    @NotBlank
+    @ApiModelProperty(value = "새 비밀번호", required = true)
     private String newPassword;
 }

--- a/src/main/java/mallang_trip/backend/domain/user/dto/SignupRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/user/dto/SignupRequest.java
@@ -1,19 +1,12 @@
 package mallang_trip.backend.domain.user.dto;
 
 import io.swagger.annotations.ApiModelProperty;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mallang_trip.backend.domain.user.constant.Country;
-import mallang_trip.backend.domain.user.constant.Gender;
-import mallang_trip.backend.domain.user.constant.Role;
-import mallang_trip.backend.domain.user.entity.User;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Builder
@@ -22,29 +15,33 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class SignupRequest {
 
     @NotBlank
-    @ApiModelProperty(value = "로그인 아이디")
+    @ApiModelProperty(value = "로그인 아이디", required = true)
     private String id;
 
     @NotBlank
+    @ApiModelProperty(value = "비밀번호", required = true)
     private String password;
 
     @NotBlank
     @Email
+    @ApiModelProperty(value = "이메일", required = true)
     private String email;
 
     @NotBlank
-    @ApiModelProperty(value = "local/foreigner")
+    @ApiModelProperty(value = "내/외국인", notes = "local/foreigner 중 하나", required = true)
     private String country;
 
     @NotBlank
+    @ApiModelProperty(value = "닉네임", required = true)
     private String nickname;
 
     @NotBlank
+    @ApiModelProperty(value = "본인인증 imp_uid", required = true)
     private String impUid;
 
-    @ApiModelProperty(value = "생략가능")
+    @ApiModelProperty(value = "자기소개", required = false)
     private String introduction;
 
-    @ApiModelProperty(value = "생략가능")
+    @ApiModelProperty(value = "프로필 이미지 URL", required = false)
     private String profileImg;
 }

--- a/src/main/java/mallang_trip/backend/domain/user/service/CurrentUserService.java
+++ b/src/main/java/mallang_trip/backend/domain/user/service/CurrentUserService.java
@@ -1,6 +1,5 @@
 package mallang_trip.backend.domain.user.service;
 
-import static mallang_trip.backend.domain.user.exception.UserExceptionStatus.CANNOT_FOUND_USER;
 import static mallang_trip.backend.global.io.BaseResponseStatus.Unauthorized;
 
 import lombok.RequiredArgsConstructor;
@@ -34,7 +33,7 @@ public class CurrentUserService {
         }
         User user = authentication.getName().equals("anonymousUser") ? null
             : userRepository.findById(Long.parseLong(authentication.getName()))
-                .orElseThrow(() -> new BaseException(CANNOT_FOUND_USER));
+                .orElseThrow(() -> new BaseException(Unauthorized));
         return user;
     }
 

--- a/src/main/java/mallang_trip/backend/domain/user/service/UserSearchService.java
+++ b/src/main/java/mallang_trip/backend/domain/user/service/UserSearchService.java
@@ -1,6 +1,6 @@
 package mallang_trip.backend.domain.user.service;
 
-import static mallang_trip.backend.global.io.BaseResponseStatus.Not_Found;
+import static mallang_trip.backend.domain.user.exception.UserExceptionStatus.CANNOT_FOUND_USER;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,7 +42,7 @@ public class UserSearchService {
 	 */
 	public UserBriefResponse getUserBriefInfo(Long userId) {
 		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new BaseException(Not_Found));
+			.orElseThrow(() -> new BaseException(CANNOT_FOUND_USER));
 		return UserBriefResponse.of(user);
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
+++ b/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
@@ -6,11 +6,6 @@ import static mallang_trip.backend.global.io.BaseResponseStatus.Unauthorized;
 import static mallang_trip.backend.domain.user.constant.Role.ROLE_USER;
 import static mallang_trip.backend.domain.user.exception.UserExceptionStatus.CANNOT_FOUND_USER;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.UnsupportedEncodingException;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import mallang_trip.backend.global.config.security.TokenProvider;
@@ -54,7 +49,7 @@ public class UserService {
 	 * 회원가입
 	 */
 	public void signup(SignupRequest request) {
-		if(isDuplicate(request)){
+		if (isDuplicate(request)) {
 			throw new BaseException(Conflict);
 		}
 		IdentificationResultResponse.CertificationAnnotation response =
@@ -129,13 +124,12 @@ public class UserService {
 	/**
 	 * User table unique check
 	 */
-	private Boolean isDuplicate(SignupRequest request){
-		if(userRepository.existsByLoginId(request.getId())
-		|| userRepository.existsByEmail(request.getEmail())
-		|| userRepository.existsByNickname(request.getNickname())){
+	private Boolean isDuplicate(SignupRequest request) {
+		if (userRepository.existsByLoginId(request.getId())
+			|| userRepository.existsByEmail(request.getEmail())
+			|| userRepository.existsByNickname(request.getNickname())) {
 			return true;
-		}
-		else{
+		} else {
 			return false;
 		}
 	}
@@ -143,8 +137,7 @@ public class UserService {
 	/**
 	 * 인증 코드 보내기 (아이디 찾기, 비밀번호 찾기 공통)
 	 */
-	public void sendSmsCertification(String phoneNumber)
-		throws UnsupportedEncodingException, URISyntaxException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+	public void sendSmsCertification(String phoneNumber) {
 		if (!userRepository.existsByPhoneNumber(phoneNumber)) {
 			throw new BaseException(CANNOT_FOUND_USER);
 		}
@@ -155,28 +148,24 @@ public class UserService {
 	 * 아이디 찾기 (인증코드 확인)
 	 */
 	public LoginIdResponse findId(String phoneNumber, String code) {
-		if (!userRepository.existsByPhoneNumber(phoneNumber)) {
-			throw new BaseException(CANNOT_FOUND_USER);
-		}
 		if (!smsService.verifyAndDeleteCode(phoneNumber, code)) {
 			throw new BaseException(Unauthorized);
-		} else {
-			User user = userRepository.findByPhoneNumber(phoneNumber)
-				.orElseThrow(() -> new BaseException(CANNOT_FOUND_USER));
-			return LoginIdResponse.builder()
-				.loginId(user.getLoginId())
-				.build();
 		}
+
+		User user = userRepository.findByPhoneNumber(phoneNumber)
+			.orElseThrow(() -> new BaseException(CANNOT_FOUND_USER));
+
+		return LoginIdResponse.builder()
+			.loginId(user.getLoginId())
+			.build();
 	}
 
 	/**
 	 * 비밀번호 찾기 (인증코드 확인)
 	 */
-	public String findPassword(String phoneNumber, String code) {
+	public void findPassword(String phoneNumber, String code) {
 		if (!smsService.verifyAndExtendCode(phoneNumber, code)) {
 			throw new BaseException(Unauthorized);
-		} else {
-			return "성공";
 		}
 	}
 

--- a/src/main/java/mallang_trip/backend/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/mallang_trip/backend/domain/user/service/UserWithdrawalService.java
@@ -39,6 +39,7 @@ public class UserWithdrawalService {
 		// TODO: 결제 정보 저장
 		deletePersonalInformation(user);
 		chatService.leaveAllChat(user);
+		user.setRefreshToken(null);
 	}
 
 	/**

--- a/src/main/java/mallang_trip/backend/global/config/security/TokenProvider.java
+++ b/src/main/java/mallang_trip/backend/global/config/security/TokenProvider.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.global.config.security;
 
+import static mallang_trip.backend.global.io.BaseResponseStatus.Bad_Request;
 import static mallang_trip.backend.global.io.BaseResponseStatus.EXPIRED_JWT;
 import static mallang_trip.backend.global.io.BaseResponseStatus.INVALID_JWT;
 
@@ -196,6 +197,10 @@ public class TokenProvider implements InitializingBean {
 
     public String getRefreshToken() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-        return request.getHeader("REFRESH-TOKEN").substring(7);
+        try{
+            return request.getHeader("REFRESH-TOKEN").substring(7);
+        } catch(NullPointerException | StringIndexOutOfBoundsException e){
+            throw new BaseException(Bad_Request);
+        }
     }
 }

--- a/src/main/java/mallang_trip/backend/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/mallang_trip/backend/global/config/swagger/SwaggerConfig.java
@@ -1,22 +1,17 @@
 package mallang_trip.backend.global.config.swagger;
 
 import java.util.ArrayList;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.builders.RequestParameterBuilder;
+import springfox.documentation.builders.ResponseBuilder;
 import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.AuthorizationScope;
-import springfox.documentation.service.Parameter;
-import springfox.documentation.service.RequestParameter;
-import springfox.documentation.service.SecurityReference;
+import springfox.documentation.service.Response;
 import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
@@ -24,20 +19,21 @@ public class SwaggerConfig {
 
     @Bean
     public Docket api() {
-        List<RequestParameter> globalRequestParameters = new ArrayList<>();
-        globalRequestParameters.add(new RequestParameterBuilder()
-            .name("access-token")
-            .description("JWT Access Token")
-            .in("header")
-            .required(false)
-            .build());
+        ArrayList<Response> globalResponse = new ArrayList<>();
+        globalResponse.add(new ResponseBuilder().code("500")
+            .description("알 수 없는 오류.").build()
+        );
 
         return new Docket(DocumentationType.OAS_30)
             .select()
             .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
             .paths(PathSelectors.any())
             .build()
-            .globalRequestParameters(globalRequestParameters)
+            .useDefaultResponseMessages(false)
+            .globalResponses(HttpMethod.GET, globalResponse)
+            .globalResponses(HttpMethod.POST, globalResponse)
+            .globalResponses(HttpMethod.DELETE, globalResponse)
+            .globalResponses(HttpMethod.PUT, globalResponse)
             .apiInfo(apiInfo());
     }
 


### PR DESCRIPTION
**주요 변경**
1. `SwaggerConfig.java`
    - 500(”알 수 없는 오류”)를 global Response statusCode로 추가
3. User API Swagger 명세서 구체화
    - `UserController.java`: @ApiResponse, @ApiImplicitParam 어노테이션 추가
    - `dto/*Request.java`: @ApiModelProperty 어노테이션 추가
  
- 이런 식으로 Swagger 명세서를 조금 자세하게 적어볼까 하는데 어떤 것 같아?

**기타**
1. `UserWithdrawalService.java`: 회원탈퇴시 refreshToken 초기화로 기존 JWT 토큰 무효화
2. `SmsService.java`: 클래스 내부에서 발생하는 exception들을 외부로 throw하지 않고, try-catch 문으로 내부에서 처리하도록 수정