### PR TITLE
Feat/payple billing

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/party/service/PartyService.java
+++ b/src/main/java/mallang_trip/backend/domain/party/service/PartyService.java
@@ -56,6 +56,7 @@ import mallang_trip.backend.domain.party.repository.PartyRepository;
 import mallang_trip.backend.domain.reservation.service.ReservationService;
 import mallang_trip.backend.domain.chat.service.ChatService;
 import org.springframework.stereotype.Service;
+import static java.time.temporal.ChronoUnit.DAYS;
 
 @Service
 @RequiredArgsConstructor
@@ -467,7 +468,7 @@ public class PartyService {
      */
     private void cancelReservationByNotLastMember(PartyMember member) {
         Party party = member.getParty();
-        int dDay = Period.between(LocalDate.now(), party.getStartDate()).getDays();
+        long dDay = DAYS.between(LocalDate.now(), party.getStartDate());
         // 취소자 환불 진행
         Integer penaltyAmount = reservationService.refund(member);
         // 멤버 삭제

--- a/src/main/java/mallang_trip/backend/domain/payple/controller/PaypleController.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/controller/PaypleController.java
@@ -2,6 +2,7 @@ package mallang_trip.backend.domain.payple.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -15,6 +16,7 @@ import mallang_trip.backend.global.io.BaseResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -68,6 +70,25 @@ public class PaypleController {
 	@PreAuthorize("isAuthenticated()") // 로그인 사용자
 	public BaseResponse<String> delete() throws BaseException{
 		paypleService.delete();
+		return new BaseResponse<>("성공");
+	}
+
+	@ApiOperation(value = "결제 재시도", notes = "결제를 실패한 예약에 대한 결제를 재시도합니다.")
+	@PostMapping("/{reservation_id}")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "reservation_id", value = "reservation_id", required = true, paramType = "path", dataTypeClass = Long.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 403, message = "결제에 실패했습니다."),
+		@ApiResponse(code = 404, message = "해당 예약이 존재하지 않거나 등록된 카드가 없습니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+	})
+	@PreAuthorize("isAuthenticated()") // 로그인 사용자
+	public BaseResponse<String> retry(@PathVariable(value = "reservation_id") Long reservationId) throws BaseException{
+		paypleService.retry(reservationId);
 		return new BaseResponse<>("성공");
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/BillingRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/BillingRequest.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.payple.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,21 +8,54 @@ import lombok.Getter;
 @Builder
 public class BillingRequest {
 
-	private String PCD_CST_ID;
-	private String PCD_CUST_KEY;
-	private String PCD_AUTH_KEY;
-	private String PCD_PAY_TYPE;
-	private String PCD_PAYER_ID;
-	private String PCD_PAY_GOODS;
-	private String PCD_SIMPLE_FLAG;
-	private Integer PCD_PAY_TOTAL;
-	private String PCD_PAY_OID;
-	private Long PCD_PAYER_NO;
-	private String PCD_PAYER_NAME;
-	private String PCD_PAYER_HP;
-	private String PCD_PAYER_EMAIL;
-	private String PCD_PAY_ISTAX;
-	private Integer PCD_PAY_TAXTOTAL;
-	private String PCD_USER_DEFINE1;
-	private String PCD_USER_DEFINE2;
+	@JsonProperty("PCD_CST_ID")
+	private String pcd_CST_ID;
+
+	@JsonProperty("PCD_CUST_KEY")
+	private String pcd_CUST_KEY;
+
+	@JsonProperty("PCD_AUTH_KEY")
+	private String pcd_AUTH_KEY;
+
+	@JsonProperty("PCD_PAY_TYPE")
+	private String pcd_PAY_TYPE;
+
+	@JsonProperty("PCD_PAYER_ID")
+	private String pcd_PAYER_ID;
+
+	@JsonProperty("PCD_PAY_GOODS")
+	private String pcd_PAY_GOODS;
+
+	@JsonProperty("PCD_SIMPLE_FLAG")
+	private String pcd_SIMPLE_FLAG;
+
+	@JsonProperty("PCD_PAY_TOTAL")
+	private Integer pcd_PAY_TOTAL;
+
+	@JsonProperty("PCD_PAY_OID")
+	private String pcd_PAY_OID;
+
+	@JsonProperty("PCD_PAYER_NO")
+	private Long pcd_PAYER_NO;
+
+	@JsonProperty("PCD_PAYER_NAME")
+	private String pcd_PAYER_NAME;
+
+	@JsonProperty("PCD_PAYER_HP")
+	private String pcd_PAYER_HP;
+
+	@JsonProperty("PCD_PAYER_EMAIL")
+	private String pcd_PAYER_EMAIL;
+
+	@JsonProperty("PCD_PAY_ISTAX")
+	private String pcd_PAY_ISTAX;
+
+	@JsonProperty("PCD_PAY_TAXTOTAL")
+	private Integer pcd_PAY_TAXTOTAL;
+
+	@JsonProperty("PCD_USER_DEFINE1")
+	private String pcd_USER_DEFINE1;
+
+	@JsonProperty("PCD_USER_DEFINE2")
+	private String pcd_USER_DEFINE2;
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/BillingRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/BillingRequest.java
@@ -1,0 +1,27 @@
+package mallang_trip.backend.domain.payple.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BillingRequest {
+
+	private String PCD_CST_ID;
+	private String PCD_CUST_KEY;
+	private String PCD_AUTH_KEY;
+	private String PCD_PAY_TYPE;
+	private String PCD_PAYER_ID;
+	private String PCD_PAY_GOODS;
+	private String PCD_SIMPLE_FLAG;
+	private Integer PCD_PAY_TOTAL;
+	private String PCD_PAY_OID;
+	private Long PCD_PAYER_NO;
+	private String PCD_PAYER_NAME;
+	private String PCD_PAYER_HP;
+	private String PCD_PAYER_EMAIL;
+	private String PCD_PAY_ISTAX;
+	private Integer PCD_PAY_TAXTOTAL;
+	private String PCD_USER_DEFINE1;
+	private String PCD_USER_DEFINE2;
+}

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/BillingResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/BillingResponse.java
@@ -1,0 +1,35 @@
+package mallang_trip.backend.domain.payple.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BillingResponse {
+
+	private String PCD_PAY_RST;
+	private String PCD_PAY_CODE;
+	private String PCD_PAY_MSG;
+	private String PCD_PAY_OID;
+	private String PCD_PAY_TYPE;
+	private String PCD_PAYER_ID;
+	private String PCD_PAYER_NO;
+	private String PCD_PAYER_NAME;
+	private String PCD_PAYER_HP;
+	private String PCD_PAYER_EMAIL;
+	private String PCD_PAY_GOODS;
+	private String PCD_PAY_TOTAL;
+	private String PCD_PAY_TAXTOTAL;
+	private String PCD_PAY_ISTAX;
+	private String PCD_PAY_TIME;
+	private String PCD_PAY_CARDNAME;
+	private String PCD_PAY_CARDNUM;
+	private String PCD_PAY_CARDTRADENUM;
+	private String PCD_PAY_CARDAUTHNO;
+	private String PCD_PAY_CARDRECEIPT;
+	private String PCD_SIMPLE_FLAG;
+	private String PCD_USER_DEFINE1;
+	private String PCD_USER_DEFINE2;
+
+}

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/BillingResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/BillingResponse.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.payple.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,28 +9,72 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BillingResponse {
 
-	private String PCD_PAY_RST;
-	private String PCD_PAY_CODE;
-	private String PCD_PAY_MSG;
-	private String PCD_PAY_OID;
-	private String PCD_PAY_TYPE;
-	private String PCD_PAYER_ID;
-	private String PCD_PAYER_NO;
-	private String PCD_PAYER_NAME;
-	private String PCD_PAYER_HP;
-	private String PCD_PAYER_EMAIL;
-	private String PCD_PAY_GOODS;
-	private String PCD_PAY_TOTAL;
-	private String PCD_PAY_TAXTOTAL;
-	private String PCD_PAY_ISTAX;
-	private String PCD_PAY_TIME;
-	private String PCD_PAY_CARDNAME;
-	private String PCD_PAY_CARDNUM;
-	private String PCD_PAY_CARDTRADENUM;
-	private String PCD_PAY_CARDAUTHNO;
-	private String PCD_PAY_CARDRECEIPT;
-	private String PCD_SIMPLE_FLAG;
-	private String PCD_USER_DEFINE1;
-	private String PCD_USER_DEFINE2;
+	@JsonProperty("PCD_PAY_RST")
+	private String pcd_PAY_RST;
 
+	@JsonProperty("PCD_PAY_CODE")
+	private String pcd_PAY_CODE;
+
+	@JsonProperty("PCD_PAY_MSG")
+	private String pcd_PAY_MSG;
+
+	@JsonProperty("PCD_PAY_OID")
+	private String pcd_PAY_OID;
+
+	@JsonProperty("PCD_PAY_TYPE")
+	private String pcd_PAY_TYPE;
+
+	@JsonProperty("PCD_PAYER_ID")
+	private String pcd_PAYER_ID;
+
+	@JsonProperty("PCD_PAYER_NO")
+	private String pcd_PAYER_NO;
+
+	@JsonProperty("PCD_PAYER_NAME")
+	private String pcd_PAYER_NAME;
+
+	@JsonProperty("PCD_PAYER_HP")
+	private String pcd_PAYER_HP;
+
+	@JsonProperty("PCD_PAYER_EMAIL")
+	private String pcd_PAYER_EMAIL;
+
+	@JsonProperty("PCD_PAY_GOODS")
+	private String pcd_PAY_GOODS;
+
+	@JsonProperty("PCD_PAY_TOTAL")
+	private String pcd_PAY_TOTAL;
+
+	@JsonProperty("PCD_PAY_TAXTOTAL")
+	private String pcd_PAY_TAXTOTAL;
+
+	@JsonProperty("PCD_PAY_ISTAX")
+	private String pcd_PAY_ISTAX;
+
+	@JsonProperty("PCD_PAY_TIME")
+	private String pcd_PAY_TIME;
+
+	@JsonProperty("PCD_PAY_CARDNAME")
+	private String pcd_PAY_CARDNAME;
+
+	@JsonProperty("PCD_PAY_CARDNUM")
+	private String pcd_PAY_CARDNUM;
+
+	@JsonProperty("PCD_PAY_CARDTRADENUM")
+	private String pcd_PAY_CARDTRADENUM;
+
+	@JsonProperty("PCD_PAY_CARDAUTHNO")
+	private String pcd_PAY_CARDAUTHNO;
+
+	@JsonProperty("PCD_PAY_CARDRECEIPT")
+	private String pcd_PAY_CARDRECEIPT;
+
+	@JsonProperty("PCD_SIMPLE_FLAG")
+	private String pcd_SIMPLE_FLAG;
+
+	@JsonProperty("PCD_USER_DEFINE1")
+	private String pcd_USER_DEFINE1;
+
+	@JsonProperty("PCD_USER_DEFINE2")
+	private String pcd_USER_DEFINE2;
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/CancelRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/CancelRequest.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.payple.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,14 +8,31 @@ import lombok.Getter;
 @Builder
 public class CancelRequest {
 
-	private String PCD_CST_ID;
-	private String PCD_CUST_KEY;
-	private String PCD_AUTH_KEY;
-	private String PCD_REFUND_KEY;
-	private String PCD_PAYCANCEL_FLAG;
-	private String PCD_PAY_OID;
-	private String PCD_PAY_DATE;
-	private String PCD_REFUND_TOTAL;
-	private String PCD_REFUND_TAXTOTAL;
+	@JsonProperty("PCD_CST_ID")
+	private String pcd_CST_ID;
+
+	@JsonProperty("PCD_CUST_KEY")
+	private String pcd_CUST_KEY;
+
+	@JsonProperty("PCD_AUTH_KEY")
+	private String pcd_AUTH_KEY;
+
+	@JsonProperty("PCD_REFUND_KEY")
+	private String pcd_REFUND_KEY;
+
+	@JsonProperty("PCD_PAYCANCEL_FLAG")
+	private String pcd_PAYCANCEL_FLAG;
+
+	@JsonProperty("PCD_PAY_OID")
+	private String pcd_PAY_OID;
+
+	@JsonProperty("PCD_PAY_DATE")
+	private String pcd_PAY_DATE;
+
+	@JsonProperty("PCD_REFUND_TOTAL")
+	private String pcd_REFUND_TOTAL;
+
+	@JsonProperty("PCD_REFUND_TAXTOTAL")
+	private String pcd_REFUND_TAXTOTAL;
 
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/CancelRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/CancelRequest.java
@@ -1,0 +1,20 @@
+package mallang_trip.backend.domain.payple.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CancelRequest {
+
+	private String PCD_CST_ID;
+	private String PCD_CUST_KEY;
+	private String PCD_AUTH_KEY;
+	private String PCD_REFUND_KEY;
+	private String PCD_PAYCANCEL_FLAG;
+	private String PCD_PAY_OID;
+	private String PCD_PAY_DATE;
+	private String PCD_REFUND_TOTAL;
+	private String PCD_REFUND_TAXTOTAL;
+
+}

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/CancelResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/CancelResponse.java
@@ -1,0 +1,28 @@
+package mallang_trip.backend.domain.payple.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CancelResponse {
+
+	private String PCD_PAY_RST;
+	private String PCD_PAY_CODE;
+	private String PCD_PAY_MSG;
+	private String PCD_PAY_OID;
+	private String PCD_PAY_TYPE;
+	private String PCD_PAYER_NO;
+	private String PCD_PAYER_ID;
+	private String PCD_PAY_GOODS;
+	private String PCD_REGULER_FLAG;
+	private String PCD_PAY_YEAR;
+	private String PCD_PAY_MONTH;
+	private String PCD_REFUND_TOTAL;
+	private String PCD_REFUND_TAXTOTAL;
+	private String PCD_PAY_TIME;
+	private String PCD_PAY_CARDTRADENUM;
+	private String PCD_PAY_CARDRECEIPT;
+
+}

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/CancelResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/CancelResponse.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.payple.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,21 +9,52 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CancelResponse {
 
-	private String PCD_PAY_RST;
-	private String PCD_PAY_CODE;
-	private String PCD_PAY_MSG;
-	private String PCD_PAY_OID;
-	private String PCD_PAY_TYPE;
-	private String PCD_PAYER_NO;
-	private String PCD_PAYER_ID;
-	private String PCD_PAY_GOODS;
-	private String PCD_REGULER_FLAG;
-	private String PCD_PAY_YEAR;
-	private String PCD_PAY_MONTH;
-	private String PCD_REFUND_TOTAL;
-	private String PCD_REFUND_TAXTOTAL;
-	private String PCD_PAY_TIME;
-	private String PCD_PAY_CARDTRADENUM;
-	private String PCD_PAY_CARDRECEIPT;
+	@JsonProperty("PCD_PAY_RST")
+	private String pcd_PAY_RST;
+
+	@JsonProperty("PCD_PAY_CODE")
+	private String pcd_PAY_CODE;
+
+	@JsonProperty("PCD_PAY_MSG")
+	private String pcd_PAY_MSG;
+
+	@JsonProperty("PCD_PAY_OID")
+	private String pcd_PAY_OID;
+
+	@JsonProperty("PCD_PAY_TYPE")
+	private String pcd_PAY_TYPE;
+
+	@JsonProperty("PCD_PAYER_NO")
+	private String pcd_PAYER_NO;
+
+	@JsonProperty("PCD_PAYER_ID")
+	private String pcd_PAYER_ID;
+
+	@JsonProperty("PCD_PAY_GOODS")
+	private String pcd_PAY_GOODS;
+
+	@JsonProperty("PCD_REGULER_FLAG")
+	private String pcd_REGULER_FLAG;
+
+	@JsonProperty("PCD_PAY_YEAR")
+	private String pcd_PAY_YEAR;
+
+	@JsonProperty("PCD_PAY_MONTH")
+	private String pcd_PAY_MONTH;
+
+	@JsonProperty("PCD_REFUND_TOTAL")
+	private String pcd_REFUND_TOTAL;
+
+	@JsonProperty("PCD_REFUND_TAXTOTAL")
+	private String pcd_REFUND_TAXTOTAL;
+
+	@JsonProperty("PCD_PAY_TIME")
+	private String pcd_PAY_TIME;
+
+	@JsonProperty("PCD_PAY_CARDTRADENUM")
+	private String pcd_PAY_CARDTRADENUM;
+
+	@JsonProperty("PCD_PAY_CARDRECEIPT")
+	private String pcd_PAY_CARDRECEIPT;
 
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthRequest.java
@@ -11,4 +11,5 @@ public class PartnerAuthRequest {
 	private String custKey;
 	private String PCD_PAY_TYPE;
 	private String PCD_SIMPLE_FLAG;
+	private String PCD_PAY_WORK;
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthRequest.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.payple.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +10,13 @@ public class PartnerAuthRequest {
 
 	private String cst_id;
 	private String custKey;
-	private String PCD_PAY_TYPE;
-	private String PCD_SIMPLE_FLAG;
-	private String PCD_PAYCANCEL_FLAG;
+
+	@JsonProperty("PCD_PAY_TYPE")
+	private String pcd_PAY_TYPE;
+
+	@JsonProperty("PCD_SIMPLE_FLAG")
+	private String pcd_SIMPLE_FLAG;
+
+	@JsonProperty("PCD_PAYCANCEL_FLAG")
+	private String pcd_PAYCANCEL_FLAG;
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthRequest.java
@@ -11,5 +11,5 @@ public class PartnerAuthRequest {
 	private String custKey;
 	private String PCD_PAY_TYPE;
 	private String PCD_SIMPLE_FLAG;
-	private String PCD_PAY_WORK;
+	private String PCD_PAYCANCEL_FLAG;
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/dto/PartnerAuthResponse.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.payple.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,9 +14,15 @@ public class PartnerAuthResponse {
 	private String result_msg;
 	private String cst_id;
 	private String custKey;
-	private String AuthKey;
-	private String PCD_PAY_HOST;
-	private String PCD_PAY_URL;
 	private String return_url;
+
+	@JsonProperty("AuthKey")
+	private String authKey;
+
+	@JsonProperty("PCD_PAY_HOST")
+	private String pcd_PAY_HOST;
+
+	@JsonProperty("PCD_PAY_URL")
+	private String pcd_PAY_URL;
 
 }

--- a/src/main/java/mallang_trip/backend/domain/payple/exception/PaypleExceptionStatus.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/exception/PaypleExceptionStatus.java
@@ -9,6 +9,7 @@ import mallang_trip.backend.global.io.ResponseStatus;
 public enum PaypleExceptionStatus implements ResponseStatus {
 
 	CANNOT_FOUND_CARD(404, "등록된 카드가 존재하지 않습니다."),
+	BILLING_FAIL(403, "결제에 실패했습니다."),
 	;
 
 	private final int statusCode;

--- a/src/main/java/mallang_trip/backend/domain/payple/service/BillingService.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/service/BillingService.java
@@ -1,0 +1,157 @@
+package mallang_trip.backend.domain.payple.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.URISyntaxException;
+import lombok.RequiredArgsConstructor;
+import mallang_trip.backend.domain.payple.dto.BillingRequest;
+import mallang_trip.backend.domain.payple.dto.BillingResponse;
+import mallang_trip.backend.domain.payple.dto.CancelRequest;
+import mallang_trip.backend.domain.payple.dto.CancelResponse;
+import mallang_trip.backend.domain.user.entity.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BillingService {
+
+	@Value("${payple.cst-id}")
+	private String cstId;
+
+	@Value("${payple.custKey}")
+	private String custKey;
+
+	@Value("${payple.cancel-key}")
+	private String cancelKey;
+
+	private final String hostname = "https://democpay.payple.kr/php";
+
+	private final RestTemplate restTemplate;
+	private final PartnerAuthService partnerAuthService;
+
+	/**
+	 * 페이플 POST 요청에 사용될 헤더를 생성합니다.
+	 *
+	 * @return 생성된 HttpHeaders 객체
+	 */
+	private HttpHeaders setHeaders() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Referer", "https://mallangtrip.com");
+		return headers;
+	}
+
+	/**
+	 * 빌링 승인 요청을 보냅니다.
+	 *
+	 * @param billingKey 빌링키 값
+	 * @param goods 상품명 값
+	 * @param amount 결제 금액 값
+	 * @param user 결제를 진행하는 유저에 해당하는 User 객체
+	 * @return 결제 성공 시, 결제 정보가 담긴 BillingResponse 객체를 반환합니다. 결제 실패 시, null 을 반환합니다.
+	 */
+	public BillingResponse billing(String billingKey, String goods, int amount, User user) {
+		String authKey = partnerAuthService.authBeforeBilling();
+		if (authKey == null) {
+			return null;
+		}
+
+		BillingRequest request = BillingRequest.builder()
+			.PCD_CST_ID(cstId)
+			.PCD_CUST_KEY(custKey)
+			.PCD_AUTH_KEY(authKey)
+			.PCD_PAY_TYPE("card")
+			.PCD_PAYER_ID(billingKey)
+			.PCD_PAY_GOODS(goods)
+			.PCD_SIMPLE_FLAG("Y")
+			.PCD_PAY_TOTAL(amount)
+			.PCD_PAYER_NO(user.getId())
+			.PCD_PAYER_NAME(user.getName())
+			.PCD_PAYER_HP(user.getPhoneNumber())
+			.build();
+
+		try {
+			HttpHeaders headers = setHeaders();
+			ObjectMapper objectMapper = new ObjectMapper();
+			String body = objectMapper.writeValueAsString(request);
+			HttpEntity<String> httpBody = new HttpEntity<>(body, headers);
+
+			ResponseEntity<BillingResponse> responseEntity = restTemplate.postForEntity(
+				new URI(hostname + "/SimplePayCardAct.php?ACT_=PAYM"),
+				httpBody,
+				BillingResponse.class
+			);
+
+			BillingResponse response = responseEntity.getBody();
+
+			if (response.getPCD_PAY_RST().equals("success")) {
+				return response;
+			} else {
+				return null;
+			}
+
+		} catch (RestClientResponseException | URISyntaxException | JsonProcessingException ex) {
+			return null;
+		}
+	}
+
+	/**
+	 * 결제 취소 요청을 보냅니다.
+	 *
+	 * @param oid 원결제 주문번호 값
+	 * @param date 원결제 결제일자 값
+	 * @param amount 취소 금액 값
+	 * @return 취소 성공 시, 취소 정보가 담긴 CancelResponse 객체를 반환합니다. 취소에 실패하면 null 을 반환합니다.
+	 */
+	public CancelResponse cancel(String oid, String date, String amount) {
+		String authKey = partnerAuthService.authBeforeCancel();
+		if (authKey == null) {
+			return null;
+		}
+
+		CancelRequest request = CancelRequest.builder()
+			.PCD_CST_ID(cstId)
+			.PCD_CUST_KEY(custKey)
+			.PCD_AUTH_KEY(authKey)
+			.PCD_REFUND_KEY(cancelKey)
+			.PCD_PAYCANCEL_FLAG("Y")
+			.PCD_PAY_OID(oid)
+			.PCD_PAY_DATE(date)
+			.PCD_REFUND_TOTAL(amount)
+			.build();
+
+		try {
+			HttpHeaders headers = setHeaders();
+			ObjectMapper objectMapper = new ObjectMapper();
+			String body = objectMapper.writeValueAsString(request);
+			HttpEntity<String> httpBody = new HttpEntity<>(body, headers);
+
+			ResponseEntity<CancelResponse> responseEntity = restTemplate.postForEntity(
+				new URI(hostname + "/account/api/cPayCAct.php"),
+				httpBody,
+				CancelResponse.class
+			);
+
+			CancelResponse response = responseEntity.getBody();
+			if (response.getPCD_PAY_RST().equals("success")) {
+				return response;
+			} else {
+				return null;
+			}
+
+		} catch (RestClientResponseException | URISyntaxException | JsonProcessingException ex) {
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/mallang_trip/backend/domain/payple/service/PartnerAuthService.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/service/PartnerAuthService.java
@@ -35,41 +35,58 @@ public class PartnerAuthService {
 	private final String hostname = "https://cpay.payple.kr/php/auth.php";
 
 	/**
-	 * 파트너 인증 요청에 사용될 헤더를 생성합니다.
+	 * 빌링키 조회 요청을 보내기 전 과정인 파트너 인증 요청을 보냅니다.
 	 *
-	 * @return 생성된 HttpHeaders 객체
+	 * @return 인증 성공 시 페이플 서버로부터 받은 인증 정보를 담은 PartnerAuthResponse 객체를 반환합니다.
 	 */
-	private HttpHeaders setHeaders(){
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_JSON);
-		headers.set("Referer", "https://www.mallangtrip.com");
-		return headers;
+	public PartnerAuthResponse postBeforeCheckingBillingKey(){
+		PartnerAuthRequest request = PartnerAuthRequest.builder()
+			.cst_id(cstId)
+			.custKey(custKey)
+			.PCD_PAY_WORK("PUSERINFO")
+			.build();
+
+		return postPartnerAuth(request);
 	}
 
 	/**
-	 * 파트너 인증 요청에 사용될 Body 정보를 담은 DTO 객체를 생성합니다.
+	 * 빌링키 승인 요청을 보내기 전 과정인 파트너 인증 요청을 보냅니다.
 	 *
-	 * @return 생성된 PartnerAuthRequest 객체
+	 * @return 인증 성공 시 페이플 서버로부터 받은 인증 정보를 담은 PartnerAuthResponse 객체를 반환합니다.
 	 */
-	private PartnerAuthRequest createPartnerAuthRequest(){
-		return PartnerAuthRequest.builder()
+	public PartnerAuthResponse authBeforeBilling(){
+		PartnerAuthRequest request = PartnerAuthRequest.builder()
 			.cst_id(cstId)
 			.custKey(custKey)
 			.PCD_PAY_TYPE("card")
 			.PCD_SIMPLE_FLAG("Y")
 			.build();
+
+		return postPartnerAuth(request);
 	}
 
 	/**
-	 * 파트너 인증 요청을 보냅니다.
+	 * 파트너 인증 요청에 사용될 헤더를 생성합니다.
 	 *
+	 * @return 생성된 HttpHeaders 객체
+	 */
+	private HttpHeaders setHeaders() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("Referer", "https://mallangtrip.com");
+		return headers;
+	}
+
+	/**
+	 * 파트너 인증 요청(POST)을 보냅니다.
+	 *
+	 * @param request 인증 요청에 보낼 body 정보를 담은 PartnerAuthRequest 객체
 	 * @throws BaseException Internal_Server_Error 인증에 실패하거나 인증 과정에서 오류가 발생한 경우 발생하는 예외
 	 * @return 인증 성공 시 페이플 서버로부터 받은 인증 정보를 담은 PartnerAuthResponse 객체를 반환합니다.
 	 */
-	public PartnerAuthResponse postPartnerAuthRequest(){
-		PartnerAuthRequest request = createPartnerAuthRequest();
+	private PartnerAuthResponse postPartnerAuth(PartnerAuthRequest request) {
 
-		try{
+		try {
 			HttpHeaders headers = setHeaders();
 			ObjectMapper objectMapper = new ObjectMapper();
 			String body = objectMapper.writeValueAsString(request);
@@ -84,7 +101,7 @@ public class PartnerAuthService {
 				PartnerAuthResponse.class
 			);
 
-			if(!responseEntity.getBody().getResult().equals("success")){
+			if (!responseEntity.getBody().getResult().equals("success")) {
 				throw new BaseException(Internal_Server_Error);
 			}
 

--- a/src/main/java/mallang_trip/backend/domain/payple/service/PaypleService.java
+++ b/src/main/java/mallang_trip/backend/domain/payple/service/PaypleService.java
@@ -99,6 +99,7 @@ public class PaypleService {
 	 * 자동결제를 진행합니다.
 	 *
 	 * @param reservation 결제를 진행할 Reservation 객체
+	 * @return 결제 승인 시 true 를, 실패 시 false 를 반환합니다.
 	 */
 	public boolean billing(Reservation reservation){
 		User user = reservation.getMember().getUser();
@@ -129,12 +130,16 @@ public class PaypleService {
 	}
 
 	/**
-	 * 결제 재시도 (수동결제)
+	 * 결제가 실패한 예약에 대해 결제를 재시도합니다.
+	 *
+	 * @param reservationId 실패한 예약에 해당되는 reservation_id 값
+	 * @throws BaseException Forbidden 결제가 필요하지 않은 상태일 경우 발생하는 예외
+	 * @throws BaseException BILLING_FAIL 결제가 실패했을 경우 발생하는 예외
 	 */
 	public void retry(Long reservationId){
 		Reservation reservation = reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new BaseException(Not_Found));
-		if(reservation.getStatus().equals(PAYMENT_REQUIRED)){
+		if(!reservation.getStatus().equals(PAYMENT_REQUIRED)){
 			throw new BaseException(Forbidden);
 		}
 		boolean success = billing(reservation);
@@ -144,7 +149,10 @@ public class PaypleService {
 	}
 
 	/**
-	 * 결제 취소
+	 * 결제 취소룰 진행합니다.
+	 *
+	 * @param reservation 취소할 예약에 해당하는 Reservation 객체
+	 * @param refundAmount 취소 금액 값
 	 */
 	public void cancel(Reservation reservation, Integer refundAmount){
 		reservation.setRefundAmount(refundAmount);

--- a/src/main/java/mallang_trip/backend/domain/reservation/entity/Reservation.java
+++ b/src/main/java/mallang_trip/backend/domain/reservation/entity/Reservation.java
@@ -40,10 +40,13 @@ public class Reservation extends BaseEntity {
 	private Integer paymentAmount;
 
 	@Column
-	private String paymentKey;
+	private String orderId;
 
 	@Column
 	private String receiptUrl;
+
+	@Column
+	private String payTime;
 
 	@Column
 	@Builder.Default()
@@ -52,9 +55,10 @@ public class Reservation extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private ReservationStatus status;
 
-	public void savePaymentKeyAndReceiptUrl(String paymentKey, String url){
-		this.paymentKey = paymentKey;
-		this.receiptUrl = url;
+	public void saveBillingResult(String orderId, String receiptUrl, String payTime){
+		this.orderId = orderId;
+		this.receiptUrl = receiptUrl;
+		this.payTime = payTime;
 	}
 
 	public void changeStatus(ReservationStatus status){

--- a/src/main/java/mallang_trip/backend/domain/reservation/entity/Reservation.java
+++ b/src/main/java/mallang_trip/backend/domain/reservation/entity/Reservation.java
@@ -46,6 +46,9 @@ public class Reservation extends BaseEntity {
 	private String receiptUrl;
 
 	@Column
+	private String cancelReceiptUrl;
+
+	@Column
 	private String payTime;
 
 	@Column
@@ -59,6 +62,10 @@ public class Reservation extends BaseEntity {
 		this.orderId = orderId;
 		this.receiptUrl = receiptUrl;
 		this.payTime = payTime;
+	}
+
+	public void saveCancelReceipt(String cancelReceiptUrl){
+		this.cancelReceiptUrl = cancelReceiptUrl;
 	}
 
 	public void changeStatus(ReservationStatus status){

--- a/src/main/java/mallang_trip/backend/domain/reservation/service/ReservationService.java
+++ b/src/main/java/mallang_trip/backend/domain/reservation/service/ReservationService.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.reservation.service;
 
+import static java.time.temporal.ChronoUnit.DAYS;
 import static mallang_trip.backend.domain.reservation.constant.ReservationStatus.PAYMENT_COMPLETE;
 import static mallang_trip.backend.domain.reservation.constant.ReservationStatus.PAYMENT_REQUIRED;
 import static mallang_trip.backend.domain.reservation.constant.ReservationStatus.REFUND_COMPLETE;
@@ -7,7 +8,6 @@ import static mallang_trip.backend.domain.user.constant.Role.ROLE_ADMIN;
 import static mallang_trip.backend.domain.user.constant.Role.ROLE_DRIVER;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import mallang_trip.backend.domain.payple.service.PaypleService;
@@ -65,7 +65,7 @@ public class ReservationService {
 		if (paymentComplete.isPresent()) {
 			Reservation reservation = paymentComplete.get();
 			Integer refundAmount = calculateRefundAmount(reservation);
-			//paymentService.cancel(reservation, refundAmount);
+			paypleService.cancel(reservation, refundAmount);
 			return reservation.getPaymentAmount() - refundAmount;
 		}
 
@@ -91,7 +91,7 @@ public class ReservationService {
 	public void freeRefund(PartyMember member) {
 		reservationRepository.findByMemberAndStatus(member, PAYMENT_COMPLETE)
 			.ifPresent(reservation -> {
-				//paymentService.cancel(reservation, reservation.getPaymentAmount());
+				paypleService.cancel(reservation, reservation.getPaymentAmount());
 				reservation.setRefundAmount(reservation.getPaymentAmount());
 			});
 		reservationRepository.findByMemberAndStatus(member, PAYMENT_REQUIRED)
@@ -124,8 +124,8 @@ public class ReservationService {
 	 */
 	public int calculateRefundAmount(Reservation reservation) {
 		Party party = reservation.getMember().getParty();
-		int dDay = Period.between(LocalDate.now(), party.getStartDate()).getDays();
-		if (dDay <= 2) {
+		long dDay = DAYS.between(LocalDate.now(), party.getStartDate());
+/*		if (dDay <= 2) {
 			return 0;
 		} else if (dDay == 3) {
 			return (int) (reservation.getPaymentAmount() * 0.1);
@@ -139,7 +139,8 @@ public class ReservationService {
 			return (int) (reservation.getPaymentAmount() * 0.90);
 		} else {
 			return reservation.getPaymentAmount();
-		}
+		}*/
+		return reservation.getPaymentAmount();
 	}
 
 	public void savePenaltyToDriver(Party party) {
@@ -149,7 +150,7 @@ public class ReservationService {
 
 	public int calculatePenaltyToDriver(Party party) {
 		int totalPrice = party.getCourse().getTotalPrice();
-		int dDay = Period.between(LocalDate.now(), party.getStartDate()).getDays();
+		long dDay = DAYS.between(LocalDate.now(), party.getStartDate());
 		if (dDay == 0) {
 			return (int) (totalPrice * 0.4);
 		} else if (dDay == 1) {

--- a/src/main/java/mallang_trip/backend/domain/reservation/service/ReservationService.java
+++ b/src/main/java/mallang_trip/backend/domain/reservation/service/ReservationService.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import mallang_trip.backend.domain.payple.service.PaypleService;
 import mallang_trip.backend.domain.user.constant.Role;
 import mallang_trip.backend.domain.reservation.dto.ReservationResponse;
 import mallang_trip.backend.domain.party.entity.Party;
@@ -29,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationService {
 
 	private final PartyMemberService partyMemberService;
-	//private final PaymentService paymentService;
+	private final PaypleService paypleService;
 	private final CurrentUserService currentUserService;
 	private final ReservationNotificationService reservationNotificationService;
 	private final ReservationRepository reservationRepository;
@@ -51,7 +52,7 @@ public class ReservationService {
 			.member(member)
 			.paymentAmount(calculatePaymentAmount(member))
 			.build());
-		//paymentService.pay(reservation);
+		paypleService.billing(reservation);
 	}
 
 	/**


### PR DESCRIPTION
*** 주요 변경 ***
1. ```payple/dto/*.java```
    - 변수명이 대문자로 시작할 시, getter가 제대로 작동하지 않아 json 파싱에 오류가 생기는 현상 발견
    - 변수명을 소문자로 시작하도록 수정하고, JsonProperty 어노테이션으로 json 파싱 설정
2. ```PartnerAuthService.java```
    - post 요청을 보내는 코드를 재사용하도록 리펙토링
3. ```BillingService.java```
    - ```billing()```: 결제 승인 요청 함수
    - ```cancel()```: 결제 취소 요청 함수
4. ```PaypleService.java```
    - ```billing()```: 자동 결제 함수
    - ```retry()```: 결제 재시도 함수
    - ```cancel()```: 결제 취소 함수
5.  ```Reservation.java```
    - 결제 취소 매출전표를 저장하기 위한 cancelReceiptUrl 필드 추가
6. ```ReservationService.java```
    - D-day 계산 코드 오류 수정
    - 페이플 테스트 환경은 부분 취소가 불가능한 이슈로 무조건 전액 환불하도록 임시 설정

---
결제&전액 환불 테스트까지는 완료했는데, 
테스트 환경에서는 부분취소가 불가능해서, 위약금으로 인한 부분환불은 실제 환경으로 변경된 후에 테스트 해봐야 할 것 같아...!