### PR TITLE
[FEAT] ExceptionController: add SizeLimitExceededException

### DIFF
--- a/src/main/java/mallang_trip/backend/global/io/ExceptionController.java
+++ b/src/main/java/mallang_trip/backend/global/io/ExceptionController.java
@@ -2,6 +2,7 @@ package mallang_trip.backend.global.io;
 
 import java.time.DateTimeException;
 import javax.validation.ConstraintViolationException;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
@@ -62,5 +63,12 @@ public class ExceptionController {
     @ResponseBody
     public ExceptionResponse invalidRequest(DateTimeException e) {
         return ExceptionResponse.builder().message("잘못된 날짜 형식입니다.").build();
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SizeLimitExceededException.class)
+    @ResponseBody
+    public ExceptionResponse invalidRequest(SizeLimitExceededException e) {
+        return ExceptionResponse.builder().message("업로드 가능한 최대 용량을 초과했습니다.").build();
     }
 }


### PR DESCRIPTION
파일 최대 용량을 초과했을 때 발생하는 ```SizeLimitExceededException```을 처리하는 코드를 추가해줬어
그리고 용량 제한 1MB(default) -> 5MB로 변경을 위해 application.yml에 관련 설정을 추가했으니 참고해줘...!
```
spring:
  servlet:
    multipart:
      max-file-size: 5MB
      max-request-size: 5MB
```
