### PR TITLE
Feature/objection

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/admin/constant/ObjectionStatus.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/constant/ObjectionStatus.java
@@ -1,0 +1,7 @@
+package mallang_trip.backend.domain.admin.constant;
+
+public enum ObjectionStatus {
+    WAITING,
+    COMPLETE,
+    ;
+}

--- a/src/main/java/mallang_trip/backend/domain/admin/controller/ObjectionController.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/controller/ObjectionController.java
@@ -1,0 +1,75 @@
+package mallang_trip.backend.domain.admin.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import mallang_trip.backend.domain.admin.dto.ObjectionBriefResponse;
+import mallang_trip.backend.domain.admin.dto.ObjectionDetailsResponse;
+import mallang_trip.backend.domain.admin.dto.ObjectionRequest;
+import mallang_trip.backend.global.io.BaseException;
+import mallang_trip.backend.global.io.BaseResponse;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Api(tags={"Objection API","Admin API"})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/objection")
+public class ObjectionController {
+
+    // private final ObjectionService objectionService;
+
+    /**
+     * 이의제기 목록 조회
+     * @return List<ObjectionBriefResponse>
+     * @throws BaseException
+     */
+    @GetMapping
+    @ApiOperation(value = "(관리자)이의제기 목록 조회")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public BaseResponse<List<ObjectionBriefResponse>> getObjections() throws BaseException {
+        //return new BaseResponse<>(objectionService.getObjections());
+    }
+
+    /**
+     * 이의제기 상세 조회
+     * @return ObjectionDetailsResponse
+     * @throws BaseException
+     */
+    @GetMapping("/{objection_id}")
+    @ApiOperation(value = "(관리자)이의제기 상세 조회")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public BaseResponse<ObjectionDetailsResponse> viewObjection(@PathVariable(value = "objection_id") Long objectionId) throws BaseException {
+        //return new BaseResponse<>(objectionService.viewObjection(objectionId));
+    }
+
+    /**
+     * 이의제기 처리하기
+     * @return String
+     * @throws BaseException
+     */
+    @PutMapping("/{objection_id}")
+    @ApiOperation(value = "(관리자)이의제기 처리하기")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public BaseResponse<String> complete(@PathVariable(value = "objection_id") Long objectionId) throws BaseException {
+        //objectionService.complete(objectionId);
+        return new BaseResponse<>("성공");
+    }
+
+    /**
+     * 고객 이의제기하기
+     * @return String
+     * @throws BaseException
+     */
+    @PostMapping
+    @ApiOperation(value = "이의제기하기")
+    @PreAuthorize("isAuthenticated()") // 로그인 사용자
+    public BaseResponse<String> objection(
+        @RequestBody ObjectionRequest request) throws BaseException {
+        //objectionService.create(request);
+        return new BaseResponse<>("성공");
+    }
+}

--- a/src/main/java/mallang_trip/backend/domain/admin/controller/ObjectionController.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/controller/ObjectionController.java
@@ -1,12 +1,11 @@
 package mallang_trip.backend.domain.admin.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import lombok.Getter;
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import mallang_trip.backend.domain.admin.dto.ObjectionBriefResponse;
 import mallang_trip.backend.domain.admin.dto.ObjectionDetailsResponse;
 import mallang_trip.backend.domain.admin.dto.ObjectionRequest;
+import mallang_trip.backend.domain.admin.service.ObjectionService;
 import mallang_trip.backend.global.io.BaseException;
 import mallang_trip.backend.global.io.BaseResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,7 +19,7 @@ import java.util.List;
 @RequestMapping("/objection")
 public class ObjectionController {
 
-    // private final ObjectionService objectionService;
+     private final ObjectionService objectionService;
 
     /**
      * 이의제기 목록 조회
@@ -29,9 +28,16 @@ public class ObjectionController {
      */
     @GetMapping
     @ApiOperation(value = "(관리자)이의제기 목록 조회")
+    @ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class)
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+            @ApiResponse(code = 403, message = "권한이 없거나, 정지된 사용자입니다."),
+            @ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+            @ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+    })
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public BaseResponse<List<ObjectionBriefResponse>> getObjections() throws BaseException {
-        //return new BaseResponse<>(objectionService.getObjections());
+        return new BaseResponse<>(objectionService.getObjections());
     }
 
     /**
@@ -41,9 +47,19 @@ public class ObjectionController {
      */
     @GetMapping("/{objection_id}")
     @ApiOperation(value = "(관리자)이의제기 상세 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+            @ApiImplicitParam(name = "objection_id", value = "objection_id", required = true, paramType = "path", dataTypeClass = Long.class)
+    })
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+            @ApiResponse(code = 403, message = "권한이 없거나, 정지된 사용자입니다."),
+            @ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+            @ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+    })
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public BaseResponse<ObjectionDetailsResponse> viewObjection(@PathVariable(value = "objection_id") Long objectionId) throws BaseException {
-        //return new BaseResponse<>(objectionService.viewObjection(objectionId));
+        return new BaseResponse<>(objectionService.viewObjection(objectionId));
     }
 
     /**
@@ -53,9 +69,19 @@ public class ObjectionController {
      */
     @PutMapping("/{objection_id}")
     @ApiOperation(value = "(관리자)이의제기 처리하기")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+        @ApiImplicitParam(name = "objection_id", value = "objection_id", required = true, paramType = "path", dataTypeClass = Long.class)
+    })
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+            @ApiResponse(code = 403, message = "권한이 없거나, 정지된 사용자입니다."),
+            @ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+            @ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+    })
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     public BaseResponse<String> complete(@PathVariable(value = "objection_id") Long objectionId) throws BaseException {
-        //objectionService.complete(objectionId);
+        objectionService.complete(objectionId);
         return new BaseResponse<>("성공");
     }
 
@@ -66,10 +92,17 @@ public class ObjectionController {
      */
     @PostMapping
     @ApiOperation(value = "이의제기하기")
+    @ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class)
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+            @ApiResponse(code = 403, message = "권한이 없거나, 정지된 사용자입니다."),
+            @ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+            @ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+    })
     @PreAuthorize("isAuthenticated()") // 로그인 사용자
     public BaseResponse<String> objection(
         @RequestBody ObjectionRequest request) throws BaseException {
-        //objectionService.create(request);
+        objectionService.create(request);
         return new BaseResponse<>("성공");
     }
 }

--- a/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionBriefResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionBriefResponse.java
@@ -3,24 +3,25 @@ package mallang_trip.backend.domain.admin.dto;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-import mallang_trip.backend.domain.admin.constant.ReportStatus;
-import mallang_trip.backend.domain.admin.entity.Report;
+import mallang_trip.backend.domain.admin.constant.ObjectionStatus;
+import mallang_trip.backend.domain.admin.entity.Objection;
+
 
 @Getter
 @Builder
 public class ObjectionBriefResponse {
 
-    private Long reportId;
-    private String reporteeNickname;
-    private ReportStatus status;
+    private Long objectionId;
+    private String objectorNickname;
+    private ObjectionStatus status;
     private LocalDateTime createdAt;
 
-    public static ReportBriefResponse of(Report report){
-        return ReportBriefResponse.builder()
-                .reportId(report.getId())
-                .reporteeNickname(report.getReportee().getNickname())
-                .status(report.getStatus())
-                .createdAt(report.getCreatedAt())
+    public static ObjectionBriefResponse of(Objection objection){
+        return ObjectionBriefResponse.builder()
+                .objectionId(objection.getId())
+                .objectorNickname(objection.getObjector().getNickname())
+                .status(objection.getStatus())
+                .createdAt(objection.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionBriefResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionBriefResponse.java
@@ -1,0 +1,26 @@
+package mallang_trip.backend.domain.admin.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import mallang_trip.backend.domain.admin.constant.ReportStatus;
+import mallang_trip.backend.domain.admin.entity.Report;
+
+@Getter
+@Builder
+public class ObjectionBriefResponse {
+
+    private Long reportId;
+    private String reporteeNickname;
+    private ReportStatus status;
+    private LocalDateTime createdAt;
+
+    public static ReportBriefResponse of(Report report){
+        return ReportBriefResponse.builder()
+                .reportId(report.getId())
+                .reporteeNickname(report.getReportee().getNickname())
+                .status(report.getStatus())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionDetailsResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionDetailsResponse.java
@@ -3,37 +3,29 @@ package mallang_trip.backend.domain.admin.dto;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-import mallang_trip.backend.domain.admin.constant.ReportStatus;
-import mallang_trip.backend.domain.admin.constant.ReportType;
-import mallang_trip.backend.domain.admin.entity.Report;
+import mallang_trip.backend.domain.admin.constant.ObjectionStatus;
+import mallang_trip.backend.domain.admin.entity.Objection;
+
 
 @Getter
 @Builder
 public class ObjectionDetailsResponse {
 
-    private Long reportId;
-    private Long targetId;
-    private Long reporterId;
-    private Long reporteeId;
-    private String reporterNickname;
-    private String reporteeNickname;
+    private Long objectionId;
+    private Long objectorId;
+    private String objectorNickname;
     private String content;
-    private ReportStatus status;
-    private ReportType type;
+    private ObjectionStatus status;
     private LocalDateTime createdAt;
 
-    public static ReportDetailsResponse of(Report report){
-        return ReportDetailsResponse.builder()
-                .reportId(report.getId())
-                .targetId(report.getTargetId())
-                .reporterId(report.getReporter().getId())
-                .reporteeId(report.getReportee().getId())
-                .reporterNickname(report.getReporter().getNickname())
-                .reporteeNickname(report.getReportee().getNickname())
-                .content(report.getContent())
-                .status(report.getStatus())
-                .type(report.getType())
-                .createdAt(report.getCreatedAt())
+    public static ObjectionDetailsResponse of(Objection objection){
+        return ObjectionDetailsResponse.builder()
+                .objectionId(objection.getId())
+                .objectorId(objection.getObjector().getId())
+                .objectorNickname(objection.getObjector().getNickname())
+                .content(objection.getContent())
+                .status(objection.getStatus())
+                .createdAt(objection.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionDetailsResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionDetailsResponse.java
@@ -1,0 +1,39 @@
+package mallang_trip.backend.domain.admin.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import mallang_trip.backend.domain.admin.constant.ReportStatus;
+import mallang_trip.backend.domain.admin.constant.ReportType;
+import mallang_trip.backend.domain.admin.entity.Report;
+
+@Getter
+@Builder
+public class ObjectionDetailsResponse {
+
+    private Long reportId;
+    private Long targetId;
+    private Long reporterId;
+    private Long reporteeId;
+    private String reporterNickname;
+    private String reporteeNickname;
+    private String content;
+    private ReportStatus status;
+    private ReportType type;
+    private LocalDateTime createdAt;
+
+    public static ReportDetailsResponse of(Report report){
+        return ReportDetailsResponse.builder()
+                .reportId(report.getId())
+                .targetId(report.getTargetId())
+                .reporterId(report.getReporter().getId())
+                .reporteeId(report.getReportee().getId())
+                .reporterNickname(report.getReporter().getNickname())
+                .reporteeNickname(report.getReportee().getNickname())
+                .content(report.getContent())
+                .status(report.getStatus())
+                .type(report.getType())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionRequest.java
@@ -1,15 +1,18 @@
 package mallang_trip.backend.domain.admin.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
-import mallang_trip.backend.domain.admin.constant.ReportType;
+
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @Builder
 public class ObjectionRequest {
 
-    private Long reporteeId;
+    @NotBlank
+    @ApiModelProperty(value = "이의제기 내용", required = true)
     private String content;
-    private ReportType type;
-    private Long targetId;
+
+    //private Long reportId;
 }

--- a/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/dto/ObjectionRequest.java
@@ -1,0 +1,15 @@
+package mallang_trip.backend.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import mallang_trip.backend.domain.admin.constant.ReportType;
+
+@Getter
+@Builder
+public class ObjectionRequest {
+
+    private Long reporteeId;
+    private String content;
+    private ReportType type;
+    private Long targetId;
+}

--- a/src/main/java/mallang_trip/backend/domain/admin/entity/Objection.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/entity/Objection.java
@@ -41,9 +41,9 @@ public class Objection extends BaseEntity {
     @JoinColumn(name = "objector_id", nullable = false)
     private User objector;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "report_id", nullable = false)
-    private Report report;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "report_id", nullable = false)
+//    private Report report;
 
     @Column
     private String content;

--- a/src/main/java/mallang_trip/backend/domain/admin/entity/Objection.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/entity/Objection.java
@@ -1,0 +1,54 @@
+package mallang_trip.backend.domain.admin.entity;
+
+import static mallang_trip.backend.domain.admin.constant.ObjectionStatus.WAITING;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import mallang_trip.backend.domain.admin.constant.ObjectionStatus;
+import mallang_trip.backend.global.entity.BaseEntity;
+import mallang_trip.backend.domain.user.entity.User;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLDelete(sql = "UPDATE objection SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
+public class Objection extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "objector_id", nullable = false)
+    private User objector;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
+
+    @Column
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default()
+    private ObjectionStatus status = WAITING;
+}

--- a/src/main/java/mallang_trip/backend/domain/admin/repository/ObjectionRepository.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/repository/ObjectionRepository.java
@@ -1,4 +1,12 @@
 package mallang_trip.backend.domain.admin.repository;
 
-public interface ObjectionRepository {
+import mallang_trip.backend.domain.admin.constant.ObjectionStatus;
+import mallang_trip.backend.domain.admin.entity.Objection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ObjectionRepository extends JpaRepository<Objection, Long> {
+
+    List<Objection> findByStatusOrderByCreatedAtDesc(ObjectionStatus status);
 }

--- a/src/main/java/mallang_trip/backend/domain/admin/repository/ObjectionRepository.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/repository/ObjectionRepository.java
@@ -1,0 +1,4 @@
+package mallang_trip.backend.domain.admin.repository;
+
+public interface ObjectionRepository {
+}

--- a/src/main/java/mallang_trip/backend/domain/admin/service/ObjectionService.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/service/ObjectionService.java
@@ -1,4 +1,83 @@
 package mallang_trip.backend.domain.admin.service;
 
+
+import lombok.RequiredArgsConstructor;
+import mallang_trip.backend.domain.admin.dto.ObjectionBriefResponse;
+import mallang_trip.backend.domain.admin.dto.ObjectionDetailsResponse;
+import mallang_trip.backend.domain.admin.dto.ObjectionRequest;
+import mallang_trip.backend.domain.admin.entity.Objection;
+import mallang_trip.backend.domain.admin.repository.ObjectionRepository;
+import mallang_trip.backend.domain.user.entity.User;
+import mallang_trip.backend.domain.user.repository.UserRepository;
+import mallang_trip.backend.domain.user.service.CurrentUserService;
+import mallang_trip.backend.global.io.BaseException;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static mallang_trip.backend.domain.admin.constant.ObjectionStatus.COMPLETE;
+import static mallang_trip.backend.domain.admin.constant.ObjectionStatus.WAITING;
+import static mallang_trip.backend.domain.user.exception.UserExceptionStatus.CANNOT_FOUND_USER;
+import static mallang_trip.backend.global.io.BaseResponseStatus.Not_Found;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class ObjectionService {
+
+    private final CurrentUserService currentUserService;
+    private final UserRepository userRepository;
+
+    private final ObjectionRepository objectionRepository;
+
+    /** 이의제기 목록 조회
+     *
+     */
+    public List<ObjectionBriefResponse> getObjections() {
+        List<Objection> objections = Stream.concat(
+                objectionRepository.findByStatusOrderByCreatedAtDesc(WAITING).stream(),
+                objectionRepository.findByStatusOrderByCreatedAtDesc(COMPLETE).stream())
+                .collect(Collectors.toList());
+        return objections.stream()
+                .map(ObjectionBriefResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    /** 이의제기 상세 조회
+     *
+     * @param objectionId
+     */
+    public ObjectionDetailsResponse viewObjection(Long objectionId) {
+        Objection objection = objectionRepository.findById(objectionId)
+                .orElseThrow(() -> new BaseException(Not_Found));
+
+        return ObjectionDetailsResponse.of(objection);
+    }
+
+    /** 이의제기 처리하기
+     *
+     * @param objectionId
+     */
+    public void complete(Long objectionId) {
+        Objection objection = objectionRepository.findById(objectionId)
+                .orElseThrow(() -> new BaseException(Not_Found));
+        objection.setStatus(COMPLETE);
+    }
+
+    /** 고객 이의제기하기
+     *
+     * @param request
+     */
+    public void create(ObjectionRequest request) {
+        objectionRepository.save(Objection.builder()
+                .objector(currentUserService.getCurrentUser())
+                .content(request.getContent())
+//                        .report(reportService.getReport(request.getReportId()))
+                .build());
+    }
+
+
 }

--- a/src/main/java/mallang_trip/backend/domain/admin/service/ObjectionService.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/service/ObjectionService.java
@@ -1,0 +1,4 @@
+package mallang_trip.backend.domain.admin.service;
+
+public class ObjectionService {
+}


### PR DESCRIPTION
- 피그마 있는 내용 바탕으로 
- 이의제기하기 기능 추가


----

## Question


<img width="2423" alt="image" src="https://github.com/Mallang-Trip/Backend/assets/78012131/6c8d3367-747c-48b6-9274-715c84aecc6c">

- 지금 관리자 쪽에서 이의제기 내용을 볼 때, 위에 어떤 상대방의 신고에 대한 이의제기인지처럼 나와있기는 한데
- 유저 쪽에서는 **이의제기 할 때**, 제재한 것에 대한 이의제기를 하는 방식인 것 같아서 

1. 내가 이해한게 맞을지...
2. 이해한게 맞다면, 저 방식을 그대로 따르려면 이의제기 기능쪽에 Suspension 쪽 코드나 Report쪽 코드를 다 모아야할 것 같은데 
어떻게 하는게 나을지 좀 의견을 묻고 싶어
( 처리 완료 내역에서도 신고내용 / 이의제기 내용 다 엮여져 있어서 ..)
3. 아니면 일단 이의제기는 이정도로 하고, 
처리 완료 목록에서 이의제기 내용은 신고날짜를 기준으로 1주 내의 내역만 보여주게 할지 싶기는 해.
