### PR TITLE
[FEAT] 관리자 수익 관리 API

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/income/controller/IncomeAdminController.java
+++ b/src/main/java/mallang_trip/backend/domain/income/controller/IncomeAdminController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -88,6 +89,47 @@ public class IncomeAdminController {
 		@RequestBody @Valid
 		RemittanceCompleteRequest request) throws BaseException {
 		incomeAdminService.completeRemittance(incomeId, request);
+		return new BaseResponse<>("성공");
+	}
+
+	@ApiOperation(value = "(관리자)수익 금액 변경")
+	@PutMapping("/{income_id}")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "income_id", value = "income_id", required = true, paramType = "path", dataTypeClass = Long.class),
+		@ApiImplicitParam(name = "amount", value = "변경할 금액 값", required = true, paramType = "query", dataTypeClass = Integer.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 403, message = "해당 수익금 내역을 찾을 수 없습니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+	})
+	@PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
+	public BaseResponse<String> changeIncome(@PathVariable("income_id") Long incomeId,
+		@RequestParam("amount") Integer amount) throws BaseException {
+		incomeAdminService.changeIncomeAmount(incomeId, amount);
+		return new BaseResponse<>("성공");
+	}
+
+	@ApiOperation(value = "(관리자)수수료 변경")
+	@PutMapping("/commission-rate")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "partyCommissionRate", value = "파티 수익 수수료 비율", required = true, paramType = "query", dataTypeClass = Double.class),
+		@ApiImplicitParam(name = "penaltyCommissionRate", value = "위약금 수수료 비율", required = true, paramType = "query", dataTypeClass = Double.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+	})
+	@PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
+	public BaseResponse<String> changeCommissionRate(@RequestParam Double partyCommissionRate,
+		@RequestParam Double penaltyCommissionRate) throws BaseException {
+		incomeAdminService.changeCommissionRate(partyCommissionRate, penaltyCommissionRate);
 		return new BaseResponse<>("성공");
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/income/controller/IncomeAdminController.java
+++ b/src/main/java/mallang_trip/backend/domain/income/controller/IncomeAdminController.java
@@ -1,0 +1,93 @@
+package mallang_trip.backend.domain.income.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mallang_trip.backend.domain.income.dto.IncomeResponse;
+import mallang_trip.backend.domain.income.dto.RemittanceCompleteRequest;
+import mallang_trip.backend.domain.income.service.IncomeAdminService;
+import mallang_trip.backend.global.io.BaseException;
+import mallang_trip.backend.global.io.BaseResponse;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "Income Admin API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/income/admin")
+public class IncomeAdminController {
+
+	private final IncomeAdminService incomeAdminService;
+
+	@ApiOperation(value = "(관리자)월 별 수익 내역 조회")
+	@GetMapping("/monthly")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "month", value = "YYYY-MM: 월 별 조회, ALL: 전체 기간 조회", required = true, paramType = "query", dataTypeClass = String.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+	})
+	@PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
+	public BaseResponse<List<IncomeResponse>> getIncomesByMonth(
+		@RequestParam(value = "month") String month) throws BaseException {
+		return new BaseResponse<>(incomeAdminService.getIncomesByMonth(month));
+	}
+
+	@ApiOperation(value = "(관리자) 수익 삭제")
+	@DeleteMapping("/{income_id}")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "income_id", value = "income_id", required = true, paramType = "path", dataTypeClass = Long.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 403, message = "해당 수익금 내역을 찾을 수 없습니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+	})
+	@PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
+	public BaseResponse<String> deleteIncome(@PathVariable("income_id") Long incomeId)
+		throws BaseException {
+		incomeAdminService.deleteIncome(incomeId);
+		return new BaseResponse<>("성공");
+	}
+
+	@ApiOperation(value = "(관리자)송금 완료 처리")
+	@PostMapping("/remittance/{income_id}")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
+		@ApiImplicitParam(name = "income_id", value = "income_id", required = true, paramType = "path", dataTypeClass = String.class)
+	})
+	@ApiResponses({
+		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
+		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
+		@ApiResponse(code = 403, message = "해당 수익금 내역을 찾을 수 없습니다."),
+		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
+		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
+	})
+	@PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
+	public BaseResponse<String> completeRemittance(@PathVariable("income_id") Long incomeId,
+		@RequestBody @Valid
+		RemittanceCompleteRequest request) throws BaseException {
+		incomeAdminService.completeRemittance(incomeId, request);
+		return new BaseResponse<>("성공");
+	}
+}

--- a/src/main/java/mallang_trip/backend/domain/income/controller/IncomeController.java
+++ b/src/main/java/mallang_trip/backend/domain/income/controller/IncomeController.java
@@ -7,18 +7,13 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.List;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mallang_trip.backend.domain.income.dto.IncomeResponse;
-import mallang_trip.backend.domain.income.dto.RemittanceCompleteRequest;
 import mallang_trip.backend.domain.income.service.IncomeService;
 import mallang_trip.backend.global.io.BaseException;
 import mallang_trip.backend.global.io.BaseResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -61,23 +56,4 @@ public class IncomeController {
 		return new BaseResponse<>(incomeService.getRemittedIncomes());
 	}
 
-	@ApiOperation(value = "(관리자)송금 완료 처리")
-	@PostMapping("/remittance/{income_id}")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class),
-		@ApiImplicitParam(name = "income_id", value = "income_id", required = true, paramType = "path", dataTypeClass = String.class)
-	})
-	@ApiResponses({
-		@ApiResponse(code = 400, message = "잘못된 요청입니다."),
-		@ApiResponse(code = 401, message = "인증되지 않은 사용자입니다."),
-		@ApiResponse(code = 403, message = "해당 수익금 내역을 찾을 수 없습니다."),
-		@ApiResponse(code = 10002, message = "유효하지 않은 Refresh Token 입니다."),
-		@ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
-	})
-	@PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
-	public BaseResponse<String> completeRemittance (@PathVariable("income_id") Long incomeId, @RequestBody @Valid
-		RemittanceCompleteRequest request) throws BaseException {
-		incomeService.completeRemittance(incomeId, request);
-		return new BaseResponse<>("성공");
-	}
 }

--- a/src/main/java/mallang_trip/backend/domain/income/dto/IncomeResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/income/dto/IncomeResponse.java
@@ -19,6 +19,10 @@ public class IncomeResponse {
 	private Integer beforeCommission;
 	private Integer commission;
 	private Integer afterCommission;
+	private LocalDate remittedAt;
+	private String senderBank;
+	private String receiverBank;
+	private String receiverAccountNumber;
 
 	public static IncomeResponse of(Income income){
 		return IncomeResponse.builder()
@@ -31,6 +35,10 @@ public class IncomeResponse {
 			.beforeCommission(income.getAmount())
 			.commission(income.getCommission())
 			.afterCommission(income.getAmount() - income.getCommission())
+			.remittedAt(income.getRemittedAt())
+			.senderBank(income.getSenderBank())
+			.receiverBank(income.getReceiverBank())
+			.receiverAccountNumber(income.getReceiverAccountNumber())
 			.build();
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/income/dto/RemittanceCompleteRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/income/dto/RemittanceCompleteRequest.java
@@ -1,6 +1,7 @@
 package mallang_trip.backend.domain.income.dto;
 
 import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,6 +10,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RemittanceCompleteRequest {
+
+	@ApiModelProperty(value = "거래 일자(YYYY-MM-DD)", required = true)
+	private LocalDate remittedAt;
 
 	@NotBlank
 	@ApiModelProperty(value = "송금 은행", required = true)

--- a/src/main/java/mallang_trip/backend/domain/income/entity/CommissionRate.java
+++ b/src/main/java/mallang_trip/backend/domain/income/entity/CommissionRate.java
@@ -1,0 +1,35 @@
+package mallang_trip.backend.domain.income.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mallang_trip.backend.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommissionRate extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column
+	private Double partyCommissionRate;
+
+	@Column
+	private Double penaltyCommissionRate;
+
+	public void changeCommissionRate(double partyCommissionRate, double penaltyCommissionRate) {
+		this.partyCommissionRate = partyCommissionRate;
+		this.penaltyCommissionRate = penaltyCommissionRate;
+	}
+}

--- a/src/main/java/mallang_trip/backend/domain/income/entity/Income.java
+++ b/src/main/java/mallang_trip/backend/domain/income/entity/Income.java
@@ -32,7 +32,7 @@ import org.hibernate.annotations.Where;
 @AllArgsConstructor
 @NoArgsConstructor
 @Where(clause = "deleted = false")
-@SQLDelete(sql = "UPDATE icome SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE income SET deleted = true WHERE id = ?")
 public class Income extends BaseEntity {
 
 	@Id
@@ -43,7 +43,7 @@ public class Income extends BaseEntity {
 	@JoinColumn(name = "party_id", nullable = false, updatable = false)
 	private Party party;
 
-	@Column(nullable = false, updatable = false)
+	@Column(nullable = false)
 	private Integer amount;
 
 	@Column
@@ -71,20 +71,6 @@ public class Income extends BaseEntity {
 	private String receiverAccountNumber;
 
 	/**
-	 * DB에 엔티티를 저장하기 전, 수수료를 계산합니다.
-	 * <p>
-	 * 파티 수익 수수료는 1.7%, 위약금 수익 수수료는 10%로 계산합니다.
-	 */
-	@PrePersist
-	public void calculateCommission() {
-		if (this.type.equals(PARTY_INCOME)) {
-			this.commission = (int) (this.amount * 0.017);
-		} else if (this.type.equals(PENALTY_INCOME)) {
-			this.commission = (int) (this.amount * 0.1);
-		}
-	}
-
-	/**
 	 * 송금 완료 처리합니다.
 	 */
 	public void completeRemittance(RemittanceCompleteRequest request) {
@@ -93,5 +79,13 @@ public class Income extends BaseEntity {
 		this.senderBank = request.getSenderBank();
 		this.receiverBank = request.getReceiverBank();
 		this.receiverAccountNumber = request.getReceiverAccountNumber();
+	}
+
+	/**
+	 * 수익 금액, 수수료 금액을 변경합니다.
+	 */
+	public void changeAmount(int amount, int commission){
+		this.amount = amount;
+		this.commission = commission;
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/income/entity/Income.java
+++ b/src/main/java/mallang_trip/backend/domain/income/entity/Income.java
@@ -3,6 +3,7 @@ package mallang_trip.backend.domain.income.entity;
 import static mallang_trip.backend.domain.income.constant.IncomeType.PARTY_INCOME;
 import static mallang_trip.backend.domain.income.constant.IncomeType.PENALTY_INCOME;
 
+import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -31,7 +32,7 @@ import org.hibernate.annotations.Where;
 @AllArgsConstructor
 @NoArgsConstructor
 @Where(clause = "deleted = false")
-@SQLDelete(sql = "UPDATE driver SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE icome SET deleted = true WHERE id = ?")
 public class Income extends BaseEntity {
 
 	@Id
@@ -58,6 +59,9 @@ public class Income extends BaseEntity {
 	private Boolean remitted = false;
 
 	@Column
+	private LocalDate remittedAt;
+
+	@Column
 	private String senderBank;
 
 	@Column
@@ -73,9 +77,9 @@ public class Income extends BaseEntity {
 	 */
 	@PrePersist
 	public void calculateCommission() {
-		if(this.type.equals(PARTY_INCOME)){
+		if (this.type.equals(PARTY_INCOME)) {
 			this.commission = (int) (this.amount * 0.017);
-		} else if (this.type.equals(PENALTY_INCOME)){
+		} else if (this.type.equals(PENALTY_INCOME)) {
 			this.commission = (int) (this.amount * 0.1);
 		}
 	}
@@ -83,8 +87,9 @@ public class Income extends BaseEntity {
 	/**
 	 * 송금 완료 처리합니다.
 	 */
-	public void completeRemittance(RemittanceCompleteRequest request){
+	public void completeRemittance(RemittanceCompleteRequest request) {
 		this.remitted = true;
+		this.remittedAt = request.getRemittedAt();
 		this.senderBank = request.getSenderBank();
 		this.receiverBank = request.getReceiverBank();
 		this.receiverAccountNumber = request.getReceiverAccountNumber();

--- a/src/main/java/mallang_trip/backend/domain/income/repository/CommissionRateRepository.java
+++ b/src/main/java/mallang_trip/backend/domain/income/repository/CommissionRateRepository.java
@@ -1,0 +1,10 @@
+package mallang_trip.backend.domain.income.repository;
+
+import mallang_trip.backend.domain.income.entity.CommissionRate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommissionRateRepository extends JpaRepository<CommissionRate, Long> {
+
+}

--- a/src/main/java/mallang_trip/backend/domain/income/repository/IncomeRepository.java
+++ b/src/main/java/mallang_trip/backend/domain/income/repository/IncomeRepository.java
@@ -39,4 +39,19 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
 	List<Income> findByDriverAndPeriod(@Param("driver_id") Long driverId,
 		@Param("start_date") String startDate, @Param("end_date") String endDate);
 
+	@Query(value = "SELECT i.*\n"
+		+ "FROM income i JOIN party p ON i.party_id = p.id\n"
+		+ "WHERE i.deleted = false\n"
+		+ "ORDER BY p.end_date DESC;", nativeQuery = true)
+	List<Income> findAllOrderByEndDateDesc();
+
+	@Query(value = "SELECT i.*\n"
+		+ "FROM income i\n"
+		+ "    JOIN party p ON i.party_id = p.id\n"
+		+ "WHERE i.deleted = false\n"
+		+ "    AND p.end_date >= :start_date\n"
+		+ "    AND p.end_date < :end_date\n"
+		+ "ORDER BY p.end_Date DESC;", nativeQuery = true)
+	List<Income> findByPeriod(@Param("start_date") String startDate,
+		@Param("end_date") String endDate);
 }

--- a/src/main/java/mallang_trip/backend/domain/income/service/IncomeAdminService.java
+++ b/src/main/java/mallang_trip/backend/domain/income/service/IncomeAdminService.java
@@ -1,0 +1,72 @@
+package mallang_trip.backend.domain.income.service;
+
+import static mallang_trip.backend.global.io.BaseResponseStatus.Bad_Request;
+import static mallang_trip.backend.global.io.BaseResponseStatus.Not_Found;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import mallang_trip.backend.domain.income.dto.IncomeResponse;
+import mallang_trip.backend.domain.income.dto.RemittanceCompleteRequest;
+import mallang_trip.backend.domain.income.entity.Income;
+import mallang_trip.backend.domain.income.repository.IncomeRepository;
+import mallang_trip.backend.global.io.BaseException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class IncomeAdminService {
+
+	private final IncomeRepository incomeRepository;
+
+	/**
+	 * (관리자) 월 별 수익 내역을 조회합니다.
+	 *
+	 * @param month 조회할 날짜 (YYYY-MM: 월 별 조회, all: 전체 기간 조회)
+	 */
+	public List<IncomeResponse> getIncomesByMonth(String month){
+		// 전체 조회 시
+		if(month.equalsIgnoreCase("ALL")){
+			return incomeRepository.findAllOrderByEndDateDesc().stream()
+				.map(IncomeResponse::of)
+				.collect(Collectors.toList());
+		}
+		// YYYY-MM format check
+		if (!Pattern.matches("\\d{4}-\\d{2}", month)) {
+			throw new BaseException(Bad_Request);
+		}
+
+		LocalDate startDate = LocalDate.parse(month + "-01");
+		LocalDate endDate = startDate.plusMonths(1);
+
+		return incomeRepository.findByPeriod(startDate.toString(), endDate.toString()).stream()
+			.map(IncomeResponse::of)
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * (관리자) 수익 내역을 삭제(soft delete)합니다.
+	 *
+	 * @param incomeId 삭제할 수익에 해당하는 id 값
+	 */
+	public void deleteIncome(Long incomeId){
+		Income income = incomeRepository.findById(incomeId)
+			.orElseThrow(() -> new BaseException(Not_Found));
+		incomeRepository.delete(income);
+	}
+
+	/**
+	 * (관리자) 송금 완료 처리합니다.
+	 *
+	 * @param incomeId 송금 완료 처리할 Income id 값
+	 */
+	public void completeRemittance(Long incomeId, RemittanceCompleteRequest request) {
+		Income income = incomeRepository.findById(incomeId)
+			.orElseThrow(() -> new BaseException(Not_Found));
+		income.completeRemittance(request);
+	}
+}

--- a/src/main/java/mallang_trip/backend/domain/income/service/IncomeAdminService.java
+++ b/src/main/java/mallang_trip/backend/domain/income/service/IncomeAdminService.java
@@ -27,6 +27,8 @@ public class IncomeAdminService {
 	private final CommissionRateRepository commissionRateRepository;
 	private final IncomeService incomeService;
 
+	private final Long commissionRateId = 1L;
+
 	/**
 	 * (관리자) 월 별 수익 내역을 조회합니다.
 	 *
@@ -93,7 +95,7 @@ public class IncomeAdminService {
 	 * @param penaltyCommissionRate 변경할 위약금 수수료 비율
 	 */
 	public void changeCommissionRate(double partyCommissionRate, double penaltyCommissionRate) {
-		CommissionRate rate = commissionRateRepository.findById(1L).get();
+		CommissionRate rate = commissionRateRepository.findById(commissionRateId).get();
 		rate.changeCommissionRate(partyCommissionRate, penaltyCommissionRate);
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/income/service/IncomeService.java
+++ b/src/main/java/mallang_trip/backend/domain/income/service/IncomeService.java
@@ -31,6 +31,8 @@ public class IncomeService {
 	private final IncomeRepository incomeRepository;
 	private final CommissionRateRepository commissionRateRepository;
 
+	private final Long commissionRateId = 1L;
+
 	/**
 	 * 수익금을 저장합니다.
 	 *
@@ -55,7 +57,7 @@ public class IncomeService {
 	 */
 	public int calculateCommission(IncomeType type, Integer amount){
 		// 수수료 계산
-		CommissionRate rate = commissionRateRepository.findById(1L).get();
+		CommissionRate rate = commissionRateRepository.findById(commissionRateId).get();
 		int commission = 0;
 		if (type.equals(PARTY_INCOME)) {
 			commission = (int) (amount * rate.getPartyCommissionRate());

--- a/src/main/java/mallang_trip/backend/domain/income/service/IncomeService.java
+++ b/src/main/java/mallang_trip/backend/domain/income/service/IncomeService.java
@@ -1,5 +1,6 @@
 package mallang_trip.backend.domain.income.service;
 
+import static mallang_trip.backend.domain.income.constant.IncomeType.PARTY_INCOME;
 import static mallang_trip.backend.domain.income.constant.IncomeType.PENALTY_INCOME;
 import static mallang_trip.backend.global.io.BaseResponseStatus.Bad_Request;
 
@@ -12,6 +13,8 @@ import mallang_trip.backend.domain.driver.service.DriverService;
 import mallang_trip.backend.domain.income.constant.IncomeType;
 import mallang_trip.backend.domain.income.dto.IncomeResponse;
 import mallang_trip.backend.domain.driver.entity.Driver;
+import mallang_trip.backend.domain.income.entity.CommissionRate;
+import mallang_trip.backend.domain.income.repository.CommissionRateRepository;
 import mallang_trip.backend.domain.income.repository.IncomeRepository;
 import mallang_trip.backend.domain.party.entity.Party;
 import mallang_trip.backend.global.io.BaseException;
@@ -26,6 +29,7 @@ public class IncomeService {
 
 	private final DriverService driverService;
 	private final IncomeRepository incomeRepository;
+	private final CommissionRateRepository commissionRateRepository;
 
 	/**
 	 * 수익금을 저장합니다.
@@ -39,7 +43,27 @@ public class IncomeService {
 			.party(party)
 			.amount(amount)
 			.type(type)
+			.commission(calculateCommission(type, amount))
 			.build());
+	}
+
+	/**
+	 * 수익의 수수료를 계산합니다.
+	 *
+	 * @param type 수익 종류
+	 * @param amount 전체 수익 금액
+	 */
+	public int calculateCommission(IncomeType type, Integer amount){
+		// 수수료 계산
+		CommissionRate rate = commissionRateRepository.findById(1L).get();
+		int commission = 0;
+		if (type.equals(PARTY_INCOME)) {
+			commission = (int) (amount * rate.getPartyCommissionRate());
+		} else if (type.equals(PENALTY_INCOME)) {
+			commission = (int) (amount * rate.getPenaltyCommissionRate());
+		}
+
+		return commission;
 	}
 
 	/**

--- a/src/main/java/mallang_trip/backend/domain/income/service/IncomeService.java
+++ b/src/main/java/mallang_trip/backend/domain/income/service/IncomeService.java
@@ -2,7 +2,6 @@ package mallang_trip.backend.domain.income.service;
 
 import static mallang_trip.backend.domain.income.constant.IncomeType.PENALTY_INCOME;
 import static mallang_trip.backend.global.io.BaseResponseStatus.Bad_Request;
-import static mallang_trip.backend.global.io.BaseResponseStatus.Not_Found;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,7 +12,6 @@ import mallang_trip.backend.domain.driver.service.DriverService;
 import mallang_trip.backend.domain.income.constant.IncomeType;
 import mallang_trip.backend.domain.income.dto.IncomeResponse;
 import mallang_trip.backend.domain.driver.entity.Driver;
-import mallang_trip.backend.domain.income.dto.RemittanceCompleteRequest;
 import mallang_trip.backend.domain.income.repository.IncomeRepository;
 import mallang_trip.backend.domain.party.entity.Party;
 import mallang_trip.backend.global.io.BaseException;
@@ -104,17 +102,6 @@ public class IncomeService {
 			.stream()
 			.map(IncomeResponse::of)
 			.collect(Collectors.toList());
-	}
-
-	/**
-	 * (관리자) 송금 완료 처리합니다.
-	 *
-	 * @param incomeId 송금 완료 처리할 DriverIncome id 값
-	 */
-	public void completeRemittance(Long incomeId, RemittanceCompleteRequest request) {
-		Income income = incomeRepository.findById(incomeId)
-			.orElseThrow(() -> new BaseException(Not_Found));
-		income.completeRemittance(request);
 	}
 
 }


### PR DESCRIPTION
***관리자 총 수익 API***
1. ```IncomeAdminService```, ```IncomeAdminController```
    - 월 별 수익 조회 API
    - 수익 삭제 API (soft delete)
 
2. 기존 '송금 완료 API' 의 위치를 ```IncomeAdminService```, ```IncomeAdminController```으로 이동

3. 송금 완료 처리 시, 거래일자를 추가로 받도록 수정

4. ```IncomeResponse``` dto에서 송금 정보를 추가로 보내도록 수정

---
몇 가지 구현이 안된 부분이 있는데
1. 파티명 검색: 
    프론트에서 처리하는게 효율적일 것 같아서 제외 
3. 수익 금액 수정:
    피그마에 기능에 대한 구체적인 설명이 없어서 일단 보류
5. 수수료 비율 변경 
    API 요청으로 수수료 비율을 변경하려면
    수수료 비율을 DB에 저장해두고, 변경 요청이 오면 DB를 업데이트하는 변경하는 방식... 밖에 생각나지 않네
    애초에 수수료 값을 외부에서 변경할 수 있도록 해도 되나...? 라는 생각이 들기도 하는데, 어떻게 생각해?

시험기간이라 바쁠텐데 천천히 확인하고 알려줘!