### PR TITLE
[FIX] 탈퇴한 파티 조회

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/party/constant/PartyStatus.java
+++ b/src/main/java/mallang_trip/backend/domain/party/constant/PartyStatus.java
@@ -12,9 +12,7 @@ public enum PartyStatus {
     CANCELED_BY_EXPIRATION, // 모집 기간 만료로 인한 취소
     CANCELED_BY_ALL_QUIT, // 파티원 전원 탈퇴로 인한 취소
     CANCELED_BY_DRIVER_QUIT, // 드라이버 탈퇴로 인한 취소
-    CANCELED_BY_USER_QUIT, // 파티원 탈퇴로 인한 취소
-    CANCELED_BY_REFUND, // 환불로 인한 취소
-    CANCELED_BY_REFUND_FAILED, // 환불 실패로 인한 취소
+    CANCELED_BY_USER_QUIT, // 내가 탈퇴한 파티
     DAY_OF_TRAVEL, // 여행 당일
     FINISHED, // 종료
     ;

--- a/src/main/java/mallang_trip/backend/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/mallang_trip/backend/domain/reservation/repository/ReservationRepository.java
@@ -19,5 +19,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 		+ "    AND (status = 'PAYMENT_FAILED' OR status = 'PAYMENT_COMPLETE');", nativeQuery = true)
 	Optional<Reservation> findPaymentCompletedOrFailedByMember(@Param(value = "member_id") Long memberId);
 
-	Optional<Reservation> findByPartyMemberId(Long partyMemberId);
+	Optional<Reservation> findByMember(PartyMember member);
 }


### PR DESCRIPTION
지금 상태로는 내가 탈퇴한 파티에 대해서
결제가 진행된 경우, 결제가 진행되지 않은 경우를 구별하기가 어려운 상태인 것 같아

그래서 일단은 내가 나간 모든 파티는 status를 CANCELED_BY_USER_QUIT로 표기하도록 변경했어
