### PR TITLE
[FEAT] redlock 중복 회원가입 방지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.19.1'
 
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
+++ b/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
@@ -80,6 +80,8 @@ public class UserService {
 				.profileImage(request.getProfileImg())
 				.role(ROLE_USER)
 				.build());
+		} catch (BaseException ex) {
+			throw ex;
 		} finally {
 			lock.unlock();
 		}

--- a/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
+++ b/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
@@ -20,6 +20,8 @@ import mallang_trip.backend.domain.user.constant.Gender;
 import mallang_trip.backend.domain.user.entity.User;
 import mallang_trip.backend.domain.sms.service.SmsService;
 import mallang_trip.backend.domain.user.repository.UserRepository;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -39,8 +41,7 @@ public class UserService {
 	private final CurrentUserService currentUserService;
 	private final SmsService smsService;
 	private final PortOneIdentificationService portOneIdentificationService;
-
-	private final UserSearchService userSearchService;
+	private final RedissonClient redissonClient;
 
 	/**
 	 * 회원 가입을 처리하는 메소드입니다.
@@ -49,31 +50,39 @@ public class UserService {
 	 * @throws BaseException 중복된 회원 정보가 있을 경우 발생하는 예외
 	 */
 	public void signup(SignupRequest request) {
-		if (isDuplicate(request)) {
-			throw new BaseException(Conflict);
+		RLock lock = redissonClient.getLock("signup-lock:" + request.getId());
+
+		try {
+			lock.lock();
+
+			if (isDuplicate(request)) {
+				throw new BaseException(Conflict);
+			}
+
+			IdentificationResultResponse.CertificationAnnotation response =
+				portOneIdentificationService.get(request.getImpUid()).getResponse();
+
+			if(!response.getName().equals(request.getName()) || !response.getPhone().equals(request.getPhone())){
+				throw new BaseException(Forbidden);
+			}
+
+			userRepository.save(User.builder()
+				.loginId(request.getId())
+				.password(passwordEncoder.encode(request.getPassword()))
+				.email(request.getEmail())
+				.name(response.getName())
+				.birthday(LocalDate.parse(response.getBirthday()))
+				.country(Country.from(request.getCountry()))
+				.gender(Gender.from(response.getGender()))
+				.phoneNumber(response.getPhone())
+				.nickname(request.getNickname())
+				.introduction(request.getIntroduction())
+				.profileImage(request.getProfileImg())
+				.role(ROLE_USER)
+				.build());
+		} finally {
+			lock.unlock();
 		}
-
-		IdentificationResultResponse.CertificationAnnotation response =
-			portOneIdentificationService.get(request.getImpUid()).getResponse();
-
-		if(!response.getName().equals(request.getName()) || !response.getPhone().equals(request.getPhone())){
-			throw new BaseException(Forbidden);
-		}
-
-		userRepository.save(User.builder()
-			.loginId(request.getId())
-			.password(passwordEncoder.encode(request.getPassword()))
-			.email(request.getEmail())
-			.name(response.getName())
-			.birthday(LocalDate.parse(response.getBirthday()))
-			.country(Country.from(request.getCountry()))
-			.gender(Gender.from(response.getGender()))
-			.phoneNumber(response.getPhone())
-			.nickname(request.getNickname())
-			.introduction(request.getIntroduction())
-			.profileImage(request.getProfileImg())
-			.role(ROLE_USER)
-			.build());
 	}
 
 	/**


### PR DESCRIPTION
**주요 변경**

- 회원가입 로직에서, DB가 아닌 서비스단에서 중복 체크를 하다보니
빠르게 회원가입 버튼을 두 번 눌렀을 때, 중복으로 회원가입이 되는 이슈 발생
- Redis-lock으로 중복 요청 방지 적용 - https://winterroom.tistory.com/168

---

다행히 파티 쪽은 프론트 측에서 중복 클릭을 방지해두어서, 일단 문제가 되는 회원가입에만 lock을 걸어두었어
추후에 다른 로직에서 중복 요청 현상이 발견되면 추가적으로 lock을 적용해야 할 것 같아   