### PR TITLE
[FIX] 관리자 드라이버 면허 이미지 조회 및 수정

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/admin/controller/DriverAdminController.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/controller/DriverAdminController.java
@@ -3,13 +3,12 @@ package mallang_trip.backend.domain.admin.controller;
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import mallang_trip.backend.domain.admin.service.DriverAdminService;
-import mallang_trip.backend.domain.admin.service.UserAdminService;
 import mallang_trip.backend.domain.course.dto.CourseDetailsResponse;
 import mallang_trip.backend.domain.course.dto.CourseIdResponse;
 import mallang_trip.backend.domain.course.dto.CourseRequest;
-import mallang_trip.backend.domain.driver.dto.ChangeDriverProfileRequest;
+import mallang_trip.backend.domain.driver.dto.AdminDriverProfileRequest;
+import mallang_trip.backend.domain.driver.dto.AdminDriverProfileResponse;
 import mallang_trip.backend.domain.driver.dto.DriverRegistrationResponse;
-import mallang_trip.backend.domain.driver.dto.MyDriverProfileResponse;
 import mallang_trip.backend.global.io.BaseException;
 import mallang_trip.backend.global.io.BaseResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -108,7 +107,7 @@ public class DriverAdminController {
             @ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
     })
     @PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
-    public BaseResponse<MyDriverProfileResponse> getMyDriverProfile(@PathVariable(value = "driverId") Long driverId) throws BaseException {
+    public BaseResponse<AdminDriverProfileResponse> getDriverProfile(@PathVariable(value = "driverId") Long driverId) throws BaseException {
         return new BaseResponse<>(driverAdminService.getDriverProfile(driverId));
     }
 
@@ -130,7 +129,7 @@ public class DriverAdminController {
             @ApiResponse(code = 10003, message = "만료된 Refresh Token 입니다.")
     })
     @PreAuthorize("hasRole('ROLE_ADMIN')") // 관리자
-    public BaseResponse<String> changeMyDriverProfile(@PathVariable(value = "driverId") Long driverId, @RequestBody @Valid ChangeDriverProfileRequest request) throws BaseException {
+    public BaseResponse<String> changeDriverProfile(@PathVariable(value = "driverId") Long driverId, @RequestBody @Valid AdminDriverProfileRequest request) throws BaseException {
         driverAdminService.changeDriverProfile(driverId, request);
         return new BaseResponse<>("성공");
     }

--- a/src/main/java/mallang_trip/backend/domain/admin/service/DriverAdminService.java
+++ b/src/main/java/mallang_trip/backend/domain/admin/service/DriverAdminService.java
@@ -7,6 +7,8 @@ import mallang_trip.backend.domain.course.entity.Course;
 import mallang_trip.backend.domain.course.repository.CourseDayRepository;
 import mallang_trip.backend.domain.course.repository.CourseRepository;
 import mallang_trip.backend.domain.course.service.CourseService;
+import mallang_trip.backend.domain.driver.dto.AdminDriverProfileRequest;
+import mallang_trip.backend.domain.driver.dto.AdminDriverProfileResponse;
 import mallang_trip.backend.domain.driver.dto.ChangeDriverProfileRequest;
 import mallang_trip.backend.domain.driver.dto.DriverRegistrationResponse;
 import mallang_trip.backend.domain.driver.dto.MyDriverProfileResponse;
@@ -129,12 +131,12 @@ public class DriverAdminService {
     /**
      * (관리자) 드라이버 프로필 조회
      */
-    public MyDriverProfileResponse getDriverProfile(Long driverId) {
+    public AdminDriverProfileResponse getDriverProfile(Long driverId) {
         Driver driver = driverRepository.findByIdAndStatus(driverId, ACCEPTED)
                 .orElseThrow(() -> new BaseException(CANNOT_FOUND_DRIVER));
         User user = driver.getUser();
 
-        return MyDriverProfileResponse.builder()
+        return AdminDriverProfileResponse.builder()
                 .userId(user.getId())
                 .name(user.getName())
                 .profileImg(user.getProfileImage())
@@ -153,18 +155,21 @@ public class DriverAdminService {
                 .prices(driverService.getDriverPrice(driver))
                 .courses(courseService.getDriversCourses(user))
                 .status(driver.getStatus())
+                .taxiLicenseImg(driver.getTaxiLicenceImg())
+                .driverLicenseImg(driver.getDriverLicenceImg())
+                .insuranceLicenseImg(driver.getInsuranceLicenceImg())
                 .build();
     }
 
     /**
      * (관리자) 드라이버 프로필 수정
      */
-    public void changeDriverProfile(Long driverId, ChangeDriverProfileRequest request) {
+    public void changeDriverProfile(Long driverId, AdminDriverProfileRequest request) {
         Driver driver = driverRepository.findByIdAndStatus(driverId, ACCEPTED)
                 .orElseThrow(() -> new BaseException(CANNOT_FOUND_DRIVER));
         User user = driver.getUser();
 
-        driver.changeProfile(request);
+        driver.changeProfileByAdmin(request);
         driverService.setPrice(driver, request.getPrices());
         user.setProfileImage(request.getProfileImg());
         user.setPhoneNumber(request.getPhoneNumber());

--- a/src/main/java/mallang_trip/backend/domain/driver/dto/AdminDriverProfileRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/driver/dto/AdminDriverProfileRequest.java
@@ -1,0 +1,59 @@
+package mallang_trip.backend.domain.driver.dto;
+
+import java.util.List;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AdminDriverProfileRequest {
+
+	// 차량 정보
+	@NotBlank
+	private String vehicleModel;
+	@NotNull
+	@Min(value = 1)
+	private Integer vehicleCapacity;
+	@NotBlank
+	private String vehicleNumber;
+	@NotBlank
+	private String vehicleImg;
+
+	// 활동 가능 지역
+	@NotBlank
+	private String region;
+
+	// 입금 계좌 & 운행 가격
+	@NotBlank
+	private String bank;
+	@NotBlank
+	private String accountHolder;
+	@NotBlank
+	@Size(min = 10, max = 14)
+	private String accountNumber;
+	@NotNull
+	List<DriverPriceRequest> prices;
+
+	// 프로필 정보
+	private String profileImg;
+	private List<String> weeklyHolidays;
+	private List<String> holidays;
+	private String introduction;
+
+	@NotBlank
+	private String phoneNumber;
+
+	// license
+	@NotBlank
+	private String taxiLicenseImg;
+	@NotBlank
+	private String insuranceLicenseImg;
+	@NotBlank
+	private String driverLicenseImg;
+
+}

--- a/src/main/java/mallang_trip/backend/domain/driver/dto/AdminDriverProfileResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/driver/dto/AdminDriverProfileResponse.java
@@ -1,0 +1,36 @@
+package mallang_trip.backend.domain.driver.dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import mallang_trip.backend.domain.course.dto.CourseBriefResponse;
+import mallang_trip.backend.domain.driver.constant.DriverStatus;
+
+@Getter
+@Builder
+public class AdminDriverProfileResponse {
+
+	private Long userId;
+	private String name;
+	private String profileImg;
+	private String region;
+	private List<DayOfWeek> weeklyHoliday;
+	private List<LocalDate> holidays;
+	private String vehicleImg;
+	private String vehicleModel;
+	private String vehicleNumber;
+	private Integer vehicleCapacity;
+	private String bank;
+	private String accountHolder;
+	private String accountNumber;
+	private String phoneNumber;
+	private String introduction;
+	private List<DriverPriceResponse> prices;
+	private List<CourseBriefResponse> courses;
+	private DriverStatus status;
+	private String driverLicenseImg;
+	private String taxiLicenseImg;
+	private String insuranceLicenseImg;
+}

--- a/src/main/java/mallang_trip/backend/domain/driver/entity/Driver.java
+++ b/src/main/java/mallang_trip/backend/domain/driver/entity/Driver.java
@@ -22,6 +22,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mallang_trip.backend.domain.driver.constant.DriverStatus;
+import mallang_trip.backend.domain.driver.dto.AdminDriverProfileRequest;
 import mallang_trip.backend.domain.driver.dto.ChangeDriverProfileRequest;
 import mallang_trip.backend.domain.driver.dto.DriverRegistrationRequest;
 import mallang_trip.backend.global.entity.BaseEntity;
@@ -121,6 +122,23 @@ public class Driver extends BaseEntity {
         this.vehicleNumber = request.getVehicleNumber();
         this.vehicleCapacity = request.getVehicleCapacity();
         this.introduction = request.getIntroduction();
+        changeHoliday(request.getHolidays());
+        changeWeeklyHoliday(request.getWeeklyHolidays());
+    }
+
+    public void changeProfileByAdmin(AdminDriverProfileRequest request) {
+        this.region = request.getRegion();
+        this.bank = request.getBank();
+        this.accountHolder = request.getAccountHolder();
+        this.accountNumber = request.getAccountNumber();
+        this.vehicleImg = request.getVehicleImg();
+        this.vehicleModel = request.getVehicleModel();
+        this.vehicleNumber = request.getVehicleNumber();
+        this.vehicleCapacity = request.getVehicleCapacity();
+        this.introduction = request.getIntroduction();
+        this.driverLicenceImg = request.getDriverLicenseImg();
+        this.taxiLicenceImg = request.getTaxiLicenseImg();
+        this.insuranceLicenceImg = request.getInsuranceLicenseImg();
         changeHoliday(request.getHolidays());
         changeWeeklyHoliday(request.getWeeklyHolidays());
     }


### PR DESCRIPTION
**주요변경**
- 관리자용 프로필 조회 및 변경
    - ```AdminDriverProfileRequest.java``` ```AdminDriverProfileResponse.java``` dto 생성
    - 기존 사용하던 dto에서 ~LicenseImg 만 추가적으로 조회, 수정할 수 있도록 변경