### PR TITLE
[FIX] 공백 처리

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
+++ b/src/main/java/mallang_trip/backend/domain/user/service/UserService.java
@@ -67,7 +67,8 @@ public class UserService {
 			IdentificationResultResponse.CertificationAnnotation response =
 				portOneIdentificationService.get(request.getImpUid()).getResponse();
 
-			if(!response.getName().equals(request.getName()) || !response.getPhone().equals(request.getPhone())){
+			// 스페이스바 있어도 같은 값으로 인식
+			if(!response.getName().contains(request.getName()) || !response.getPhone().contains(request.getPhone())){
 				throw new BaseException(Forbidden);
 			}
 


### PR DESCRIPTION
##  회원가입시 이름에 공백있어도 가능
---
- 휴대폰 인증번호 시에는 공백 있어도 처리 진행 => 처리 완료 후 말랑트립 서버에서는 불가
- equals => contains로 변경