### PR TITLE
[FEAT] image size 10MB 초과시 압축

### DIFF
--- a/src/main/java/mallang_trip/backend/global/config/s3/AwsS3Uploader.java
+++ b/src/main/java/mallang_trip/backend/global/config/s3/AwsS3Uploader.java
@@ -12,9 +12,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,10 +34,50 @@ public class AwsS3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     public String bucket;
 
-    public String upload(MultipartFile multipartFile, String dirName) throws BaseException {
+    public String upload(MultipartFile multipartFile, String dirName) throws BaseException, IOException {
         File uploadFile = convert(multipartFile)        // 파일 생성
                 .orElseThrow(() -> new BaseException(FILE_CONVERT_ERROR));
 
+        // 파일 용량이 10MB 이상일 경우 압축
+        if(uploadFile.length() > 10 * 1024 * 1024) {
+            // 파일 압축
+            BufferedImage image = ImageIO.read(uploadFile);
+            BufferedImage newImage = image;
+            if (image.getHeight() > 1000 || image.getWidth() > 1000) {
+                // 이미지 크기가 1000x1000 이상일 경우 리사이징
+                // 비율 유지
+                int newWidth = 1000;
+                int newHeight = (int) Math.round(image.getHeight() * (newWidth / (double) image.getWidth()));
+                newImage = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB);  // 새 이미지 생성
+                Graphics2D g2d = newImage.createGraphics(); // 그래픽 객체 생성
+                g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR); // 이미지 품질 설정 (높은 품질)
+                g2d.drawImage(image, 0, 0, newWidth, newHeight, null); // 이미지 그리기 (리사이징)
+                g2d.dispose();  // 그래픽 객체 해제
+            }
+
+            // 압축
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            try (ImageOutputStream ios = ImageIO.createImageOutputStream(os)){
+                Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpg");
+                if(!writers.hasNext()) {
+                    throw new IOException("No writers found");
+                }
+                ImageWriter writer = writers.next();
+                writer.setOutput(ios);
+
+                ImageWriteParam param = writer.getDefaultWriteParam();
+                param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+                param.setCompressionQuality(0.5f); // 압축률 설정 (0.5)
+
+                writer.write(null, new IIOImage(newImage, null, null), param);
+                writer.dispose();
+            }
+
+            // 압축된 이미지 파일 생성
+            try(FileOutputStream fos = new FileOutputStream(uploadFile)) {
+                os.writeTo(fos); // 압축된 이미지를 원래 파일에 덮어쓰기
+            }
+        }
         return upload(uploadFile, dirName);
     }
 

--- a/src/main/java/mallang_trip/backend/global/config/s3/FileController.java
+++ b/src/main/java/mallang_trip/backend/global/config/s3/FileController.java
@@ -1,6 +1,7 @@
 package mallang_trip.backend.global.config.s3;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import mallang_trip.backend.global.io.BaseException;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Api(tags = "Image Upload API")
 @RequiredArgsConstructor
@@ -21,16 +24,17 @@ public class FileController {
     @PostMapping("/upload/signup")
     @ApiOperation(value = "회원가입 이미지 업로드")
     public String uploadSignup(@RequestParam("file") MultipartFile multipartFile)
-        throws BaseException {
+            throws BaseException, IOException {
         String fileName = awsS3Uploader.upload(multipartFile, "profile");
         return fileName;
     }
 
     @PostMapping("/upload/{dir}")
     @ApiOperation(value = "이미지 업로드")
+    @ApiImplicitParam(name = "access-token", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class)
     @PreAuthorize("isAuthenticated()") // 로그인 사용자
     public String upload(@RequestParam("file") MultipartFile multipartFile,
-        @PathVariable String dir) throws BaseException {
+        @PathVariable String dir) throws BaseException, IOException {
         String fileName = awsS3Uploader.upload(multipartFile, dir);
         return fileName;
     }


### PR DESCRIPTION
# Image 압축

-----

- 10MB초과시에 압축 코드


---
- EX) 17662 × 13632 원본
https://upload.wikimedia.org/wikipedia/commons/6/6e/%22C%22_%28Charlie%29_Stand%2C_Building_E-18_%284217%29_-_Jet_Propulsion_Laboratory_Edwards_Facility%2C_Edwards_Air_Force_Base%2C_Boron%2C_Kern_County%2C_CA_HAER_CAL%2C15-BORON.V%2C1-_%28sheet_3_of_4%29.png

- 1000 × 772 리사이징본
![a70fabfd-48d4-4d7c-9866-7bbfd586e80a_C__(Charlie)_Stand,_Building_E-18_(4217)_-_Jet_Propulsion_Laboratory_Edwards_Facility,_Edwards_Air_Force_Base,_Boron,_Kern_County,_CA_HAER_CAL,15-BORON V,1-_(sheet_3_of_4)](https://github.com/Mallang-Trip/Backend/assets/78012131/3bf337f0-dae9-426c-bc25-1b65bf770458)


---

위 예시는 압축본이 글자가 많이 깨져보이기는한데
원본자체가 워낙 큰 사이즈라 
실제 서비스할 때는 괜찮지 않을까 싶어