### PR TITLE
[FEAT] 시/도 추가

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/region/dto/RegionRequest.java
+++ b/src/main/java/mallang_trip/backend/domain/region/dto/RegionRequest.java
@@ -17,4 +17,8 @@ public class RegionRequest {
 	@NotBlank
 	@ApiModelProperty(value = "지역 이미지 URL", required = true)
 	private String image;
+
+	@NotBlank
+	@ApiModelProperty(value = "지역 소속 시/도", required = true)
+	private String province;
 }

--- a/src/main/java/mallang_trip/backend/domain/region/dto/RegionResponse.java
+++ b/src/main/java/mallang_trip/backend/domain/region/dto/RegionResponse.java
@@ -11,12 +11,14 @@ public class RegionResponse {
 	private Long regionId;
 	private String name;
 	private String image;
+	private String province;
 
 	public static RegionResponse of(Region region) {
 		return RegionResponse.builder()
 			.regionId(region.getId())
 			.name(region.getName())
 			.image(region.getImage())
+			.province(region.getProvince())
 			.build();
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/region/entity/Region.java
+++ b/src/main/java/mallang_trip/backend/domain/region/entity/Region.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mallang_trip.backend.global.entity.BaseEntity;
+import org.checkerframework.checker.units.qual.C;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -32,8 +33,12 @@ public class Region extends BaseEntity {
 	@Column(name="image", nullable = false)
 	private String image;
 
-	public void modify(String name, String image){
+	@Column
+	private String province;
+
+	public void modify(String name, String image,String province){
 		this.name = name;
 		this.image = image;
+		this.province = province;
 	}
 }

--- a/src/main/java/mallang_trip/backend/domain/region/service/RegionService.java
+++ b/src/main/java/mallang_trip/backend/domain/region/service/RegionService.java
@@ -70,7 +70,7 @@ public class RegionService {
 			throw new BaseException(REGION_NOT_EMPTY);
 		}
 
-		region.modify(request.getName(), request.getImage());
+		region.modify(request.getName(), request.getImage(), request.getProvince());
 	}
 
 	/**


### PR DESCRIPTION
## 권역별 정렬을 위한 province 정보 추가

----
- region table이 변경되면서 코드가 변경되는 부분은 저 정도만 있는 것으로 파악됨.
---
- 참고 : https://chat.google.com/room/AAAA6zI1cCA/Gu5VVXqCeEc/Gu5VVXqCeEc?cls=10
---
- dev에 올렸어야 했는데 PR쓰면서 알았네. 다음부터는 dev로 올릴게요.