### PR TITLE
fix: 예약된 파티 중 일부가 예약 완료된 파티로 넘어가지 않는 부분 수정

### DIFF
--- a/src/main/java/mallang_trip/backend/domain/party/service/PartySchedulerService.java
+++ b/src/main/java/mallang_trip/backend/domain/party/service/PartySchedulerService.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class PartySchedulerService {
 
 	private final PartyRepository partyRepository;
@@ -38,6 +37,7 @@ public class PartySchedulerService {
 	 * 24시간 초과된 제안 만료 (1분마다 반복 실행)
 	 */
 	@Scheduled(fixedDelay = 60000)
+	@Transactional
 	public void expireProposal() {
 		String yesterday = LocalDateTime.now().minusDays(1).toString();
 
@@ -57,6 +57,7 @@ public class PartySchedulerService {
 	 * 매일 0시에 파티 STATUS 업데이트
 	 */
 	@Scheduled(cron = "0 0 0 * * *")
+	@Transactional
 	public void expireParty() {
 		String today = LocalDate.now().toString();
 
@@ -102,6 +103,7 @@ public class PartySchedulerService {
 	 * 여행 시작 전날 알림 전송 (매일 18시 실행)
 	 */
 	@Scheduled(cron = "0 0 18 * * *")
+	@Transactional
 	public void handleDayBeforeTravelParties(){
 		String tomorrow = LocalDate.now().plusDays(1).toString();
 		partyRepository.findDayOfTravelParties(tomorrow).stream()
@@ -116,6 +118,7 @@ public class PartySchedulerService {
 	 * 여행 당일 시작 시간 알림 전송 (1시간마다 실행)
 	 */
 	@Scheduled(cron = "0 0 0/1 * * *")
+	@Transactional
 	public void handleStartingParties(){
 		partyRepository.findByStatus(DAY_OF_TRAVEL).stream()
 			.filter(party -> isStartTime(party))
@@ -135,6 +138,7 @@ public class PartySchedulerService {
 	 * 여행이 끝난 다음날 알림 전송 (매일 09시 실행)
 	 */
 	@Scheduled(cron = "0 0 9 * * *")
+	@Transactional
 	public void handleFinishedParties(){
 		String yesterday = LocalDate.now().minusDays(1).toString();
 		partyRepository.findFinishedParties(yesterday).stream()


### PR DESCRIPTION
# BUG REPORT

MALLANG-109

## Bug Description
`예약된 파티`중 `일부`가 여행 일자가 지나도 `예약 완료`로 넘어가지 않는 상황이 발생함.

## Troubleshooting
파티 예약 관련은 스케쥴링을 하므로, 스케쥴링 로직을 집중적으로 분석함

## Cause
1. `@Schedule`은 스프링에서 `별도의 스레드를 할당`해서 스케쥴링을 하는 방식으로, 클래스 레벨에 `@Transactional`을 선언했음에도 `스레드 단위로 영속성을 관리`하는 JPA에서는 해당 엔티티가 detached 상태가 되면서 변경 사항이 커밋되지 않을 수 있음.
2. `@Schedule`은 스프링에서 별도의 스레드를 할당하기 때문에 프록시를 거치지 않아 클래스 레벨의 `@Transactional`이 적용이 안됨.

## Solve
클래스 레벨의 `@Transactional` 선언 -> 스케쥴링 메소드의 메소드 레벨에서의 `@Transactional` 선언하면서 스케쥴링 메소드를 트랜잭션으로 묶음.
